### PR TITLE
[fix] undeclared identifier memcpy

### DIFF
--- a/jutils/jutils.cpp
+++ b/jutils/jutils.cpp
@@ -48,6 +48,7 @@
 
 #define DBG(fmt, ...)
 #include <string>
+#include <string.h>
 #include "jutils-details.hpp"
 
 namespace jni

--- a/src/MediaSync.cpp
+++ b/src/MediaSync.cpp
@@ -21,6 +21,8 @@
 #include "MediaSync.h"
 #include "jutils-details.hpp"
 
+#include <string.h>
+
 using namespace jni;
 
 int CJNIMediaSync::MEDIASYNC_ERROR_AUDIOTRACK_FAIL         = 0x00000001;


### PR DESCRIPTION
memcpy isn't defined in string anymore