### PR TITLE
Populate PowerManager::ON_AFTER_RELEASE

### DIFF
--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -32,6 +32,7 @@ void CJNIPowerManager::PopulateStaticFields()
   jhclass clazz  = find_class("android/os/PowerManager");
   FULL_WAKE_LOCK = (get_static_field<int>(clazz, "FULL_WAKE_LOCK"));
   SCREEN_BRIGHT_WAKE_LOCK = (get_static_field<int>(clazz, "SCREEN_BRIGHT_WAKE_LOCK"));
+  ON_AFTER_RELEASE = (get_static_field<int>(clazz, "ON_AFTER_RELEASE"));
 }
 
 CJNIWakeLock CJNIPowerManager::newWakeLock(int levelAndFlags, const std::string &tag)

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -37,6 +37,7 @@ public:
 
   static int FULL_WAKE_LOCK;
   static int SCREEN_BRIGHT_WAKE_LOCK;
+  static int ON_AFTER_RELEASE;
 
 private:
   CJNIPowerManager();


### PR DESCRIPTION
ON_AFTER_RELEASE gives the possibility to poke a user action after release so the screen remains some time on after video playback.