### PR TITLE
VP9 for MediaCodecCapabilities / Profiles 

### DIFF
--- a/src/MediaCodecInfo.cpp
+++ b/src/MediaCodecInfo.cpp
@@ -98,13 +98,21 @@ int CJNIMediaCodecInfoCodecProfileLevel::AACObjectERLC(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AACObjectLD(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AACObjectHE_PS(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AACObjectELD(0);
+int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile0(0);
+int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile1(0);
+int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile2(0);
+int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile2HDR(0);
+int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile3(0);
+int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile3HDR(0);
+
 const char *CJNIMediaCodecInfoCodecProfileLevel::m_classname = "android/media/MediaCodecInfo$CodecProfileLevel";
 
 void CJNIMediaCodecInfoCodecProfileLevel::PopulateStaticFields()
 {
+  jhclass clazz;
   if(GetSDKVersion() >= 16)
   {
-    jhclass clazz = find_class(m_classname);
+    clazz = find_class(m_classname);
     AVCProfileBaseline          = (get_static_field<int>(clazz, "AVCProfileBaseline"));
     AVCProfileMain              = (get_static_field<int>(clazz, "AVCProfileMain"));
     AVCProfileExtended          = (get_static_field<int>(clazz, "AVCProfileExtended"));
@@ -179,6 +187,16 @@ void CJNIMediaCodecInfoCodecProfileLevel::PopulateStaticFields()
     AACObjectLD                 = (get_static_field<int>(clazz, "AACObjectLD"));
     AACObjectHE_PS              = (get_static_field<int>(clazz, "AACObjectHE_PS"));
     AACObjectELD                = (get_static_field<int>(clazz, "AACObjectELD"));
+  }
+
+  if(GetSDKVersion() >= 24)
+  {
+    VP9Profile0                = (get_static_field<int>(clazz, "VP9Profile0"));
+    VP9Profile1                = (get_static_field<int>(clazz, "VP9Profile1"));
+    VP9Profile2                = (get_static_field<int>(clazz, "VP9Profile2"));
+    VP9Profile2HDR             = (get_static_field<int>(clazz, "VP9Profile2HDR"));
+    VP9Profile3                = (get_static_field<int>(clazz, "VP9Profile3"));
+    VP9Profile3HDR             = (get_static_field<int>(clazz, "VP9Profile3HDR"));
   }
 }
 

--- a/src/MediaCodecInfo.cpp
+++ b/src/MediaCodecInfo.cpp
@@ -243,6 +243,13 @@ int CJNIMediaCodecInfoCodecCapabilities::COLOR_QCOM_FormatYUV420SemiPlanar(0);
 int CJNIMediaCodecInfoCodecCapabilities::OMX_QCOM_COLOR_FormatYVU420SemiPlanarInterlace(0x7FA30C04);
 const char *CJNIMediaCodecInfoCodecCapabilities::m_classname = "android/media/MediaCodecInfo$CodecCapabilities";
 
+const CJNIMediaCodecInfoCodecCapabilities CJNIMediaCodecInfoCodecCapabilities::createFromProfileLevel(const std::string &mime, int profile, int level)
+{
+  return call_static_method<jhobject>(m_classname,
+    "createFromProfileLevel", "(Ljava/lang/String;II)Landroid/media/MediaCodecInfo$CodecCapabilities;",
+    jcast<jhstring>(mime), profile, level);
+}
+
 void CJNIMediaCodecInfoCodecCapabilities::PopulateStaticFields()
 {
   if(GetSDKVersion() >= 16)

--- a/src/MediaCodecInfo.cpp
+++ b/src/MediaCodecInfo.cpp
@@ -338,7 +338,7 @@ std::vector<CJNIMediaCodecInfoCodecProfileLevel> CJNIMediaCodecInfoCodecCapabili
 {
   JNIEnv *env = xbmc_jnienv();
 
-  jhobjectArray oprofileLevels = get_field<jhobjectArray>(m_object, "profileLevels");
+  jhobjectArray oprofileLevels = get_field<jhobjectArray>(m_object, "profileLevels", "[Landroid/media/MediaCodecInfo$CodecProfileLevel;");
   jsize size = env->GetArrayLength(oprofileLevels.get());
   std::vector<CJNIMediaCodecInfoCodecProfileLevel> profileLevels;
   profileLevels.reserve(size);

--- a/src/MediaCodecInfo.h
+++ b/src/MediaCodecInfo.h
@@ -108,6 +108,12 @@ public:
   static int AACObjectLD;
   static int AACObjectHE_PS;
   static int AACObjectELD;
+  static int VP9Profile0;
+  static int VP9Profile1;
+  static int VP9Profile2;
+  static int VP9Profile2HDR;
+  static int VP9Profile3;
+  static int VP9Profile3HDR;
 
 private:
   CJNIMediaCodecInfoCodecProfileLevel();

--- a/src/MediaCodecInfo.h
+++ b/src/MediaCodecInfo.h
@@ -134,6 +134,8 @@ public:
   std::vector<int> colorFormats() const;
   std::vector<CJNIMediaCodecInfoCodecProfileLevel> profileLevels() const;
 
+  static const CJNIMediaCodecInfoCodecCapabilities createFromProfileLevel(const std::string &mime, int profile, int level);
+
   static void PopulateStaticFields();
 
   static int COLOR_FormatMonochrome;


### PR DESCRIPTION
- Add static VP9 profiles (SDK 24)
- Implement CJNIMediaCodecInfoCodecCapabilities::createFromProfileLevel
- fix CJNIMediaCodecInfoCodecCapabilities::profileLevels()