### PR TITLE
fix build with -std=c++17

### DIFF
--- a/src/AudioTrack.cpp
+++ b/src/AudioTrack.cpp
@@ -55,7 +55,7 @@ void CJNIAudioTrack::PopulateStaticFields()
   }
 }
 
-CJNIAudioTrack::CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) throw(std::invalid_argument)
+CJNIAudioTrack::CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) noexcept(false)
   : CJNIBase("android/media/AudioTrack")
 {
   m_object = new_object(GetClassName(), "<init>", "(IIIIII)V",
@@ -77,7 +77,7 @@ CJNIAudioTrack::CJNIAudioTrack(int streamType, int sampleRateInHz, int channelCo
   m_object.setGlobal();
 }
 
-CJNIAudioTrack::CJNIAudioTrack(const CJNIAudioAttributes &attributes, const CJNIAudioFormat &format, int bufferSizeInBytes, int mode, int sessionId) throw(std::invalid_argument)
+CJNIAudioTrack::CJNIAudioTrack(const CJNIAudioAttributes &attributes, const CJNIAudioFormat &format, int bufferSizeInBytes, int mode, int sessionId) noexcept(false)
   : CJNIBase("android/media/AudioTrack")
 {
   m_object = new_object(GetClassName(), "<init>", "(Landroid/media/AudioAttributes;Landroid/media/AudioFormat;III)V",

--- a/src/AudioTrack.h
+++ b/src/AudioTrack.h
@@ -35,8 +35,8 @@ namespace jni
 class CJNIAudioTrack : public CJNIBase
 {
   public:
-    CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) throw(std::invalid_argument);
-    CJNIAudioTrack (const CJNIAudioAttributes &attributes, const CJNIAudioFormat &format, int bufferSizeInBytes, int mode, int sessionId) throw(std::invalid_argument);
+    CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) noexcept(false);
+    CJNIAudioTrack (const CJNIAudioAttributes &attributes, const CJNIAudioFormat &format, int bufferSizeInBytes, int mode, int sessionId) noexcept(false);
 
     void  play();
     void  pause();


### PR DESCRIPTION
Seems to fix the build issue, not sure if the solution is valid otherwise.

```
In file included from /home/ubuntu/libandroidjni/src/AudioTrack.cpp:21:
/home/ubuntu/libandroidjni/src/AudioTrack.h:38:125: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
    CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) throw(std::invalid_argument);
                                                                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/libandroidjni/src/AudioTrack.h:38:125: note: use 'noexcept(false)' instead
    CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) throw(std::invalid_argument);
                                                                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                                                            noexcept(false)
/home/ubuntu/libandroidjni/src/AudioTrack.h:39:139: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
    CJNIAudioTrack (const CJNIAudioAttributes &attributes, const CJNIAudioFormat &format, int bufferSizeInBytes, int mode, int sessionId) throw(std::invalid_argument);
                                                                                                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/libandroidjni/src/AudioTrack.h:39:139: note: use 'noexcept(false)' instead
    CJNIAudioTrack (const CJNIAudioAttributes &attributes, const CJNIAudioFormat &format, int bufferSizeInBytes, int mode, int sessionId) throw(std::invalid_argument);
                                                                                                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                                                                          noexcept(false)
/home/ubuntu/libandroidjni/src/AudioTrack.cpp:58:137: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
CJNIAudioTrack::CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) throw(std::invalid_argument)
                                                                                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/libandroidjni/src/AudioTrack.cpp:58:137: note: use 'noexcept(false)' instead
CJNIAudioTrack::CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) throw(std::invalid_argument)
                                                                                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                                                                        noexcept(false)
/home/ubuntu/libandroidjni/src/AudioTrack.cpp:80:150: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
CJNIAudioTrack::CJNIAudioTrack(const CJNIAudioAttributes &attributes, const CJNIAudioFormat &format, int bufferSizeInBytes, int mode, int sessionId) throw(std::invalid_argument)
                                                                                                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/libandroidjni/src/AudioTrack.cpp:80:150: note: use 'noexcept(false)' instead
CJNIAudioTrack::CJNIAudioTrack(const CJNIAudioAttributes &attributes, const CJNIAudioFormat &format, int bufferSizeInBytes, int mode, int sessionId) throw(std::invalid_argument)
                                                                                                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                                                                                     noexcept(false)
```