### PR TITLE
Add MediaDrm GetPropertyByteArray

### DIFF
--- a/src/MediaDrm.cpp
+++ b/src/MediaDrm.cpp
@@ -90,6 +90,23 @@ void CJNIMediaDrm::setPropertyString(const std::string &propertyName, const std:
     jcast<jhstring>(propertyName), jcast<jhstring>(value));
 }
 
+std::vector<char> CJNIMediaDrm::getPropertyByteArray(const std::string &propertyName) const
+{
+  JNIEnv *env = xbmc_jnienv();
+
+  jhbyteArray array = call_method<jhbyteArray>(m_object,
+    "getPropertyByteArray", "(Ljava/lang/String;)[B",
+    jcast<jhstring>(propertyName));
+
+  jsize size = env->GetArrayLength(array.get());
+
+  std::vector<char> result;
+  result.resize(size);
+  env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+
+  return result;
+}
+
 void CJNIMediaDrm::setPropertyByteArray(const std::string &propertyName, const std::vector<char> &value) const
 {
   JNIEnv *env = xbmc_jnienv();

--- a/src/MediaDrm.h
+++ b/src/MediaDrm.h
@@ -52,6 +52,7 @@ public:
 
   std::string getPropertyString(const std::string &propertyName) const;
   void setPropertyString(const std::string &propertyName, const std::string &value) const;
+  std::vector<char> getPropertyByteArray(const std::string &propertyName) const;
   void setPropertyByteArray(const std::string &propertyName, const std::vector<char> &value) const;
 
   CJNIMediaDrmCryptoSession getCryptoSession(const std::vector<char> &sessionId,


### PR DESCRIPTION
This add the support to getPropertyByteArray,
to allow get bytearray property value from DRM

Follow PR: https://github.com/xbmc/xbmc/pull/18810

For Kodi 20