### PR TITLE
Check SDK version before calling StorageManager.getStorageVolumes.

### DIFF
--- a/src/StorageManager.cpp
+++ b/src/StorageManager.cpp
@@ -26,5 +26,8 @@ using namespace jni;
 
 CJNIList<CJNIStorageVolume> CJNIStorageManager::getStorageVolumes()
 {
-  return call_method<jhobject>(m_object, "getStorageVolumes", "()Ljava/util/List;");
+  if (GetSDKVersion() >= 24)
+    return call_method<jhobject>(m_object, "getStorageVolumes", "()Ljava/util/List;");
+
+  return CJNIList<CJNIStorageVolume>(jhobject());
 }


### PR DESCRIPTION
StorageManager.getStorageVolumes is available since API level 24. Kodi baseline currently is API level 21.

https://developer.android.com/reference/android/os/storage/StorageManager#getStorageVolumes()