### PR TITLE
[API26+] Implement AudiofocusRequestClass + request/abandonaudiofocus

### DIFF
--- a/src/AudioFocusRequest.cpp
+++ b/src/AudioFocusRequest.cpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (C) 2021- Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AudioFocusRequest.h"
+
+#include "AudioManager.h"
+#include "ClassLoader.h"
+
+#include "jutils-details.hpp"
+
+using namespace jni;
+
+const char* CJNIAudioFocusRequestClass::m_classname = "android/media/AudioFocusRequest";
+const char* CJNIAudioFocusRequestClassBuilder::m_classname = "android/media/AudioFocusRequest$Builder";
+
+CJNIAudioFocusRequestClassBuilder::CJNIAudioFocusRequestClassBuilder(int focusgain)
+  : CJNIBase(CJNIAudioFocusRequestClassBuilder::m_classname)
+{
+  m_object = new_object(GetClassName(), "<init>", "(I)V", focusgain);
+
+  m_object.setGlobal();
+}
+
+CJNIAudioFocusRequestClass CJNIAudioFocusRequestClassBuilder::build()
+{
+  return call_method<jhobject>(m_object,
+   "build", "()Landroid/media/AudioFocusRequest;");
+}
+
+CJNIAudioFocusRequestClassBuilder CJNIAudioFocusRequestClassBuilder::setAcceptsDelayedFocusGain(bool acceptsDelayedFocusGain)
+{
+  return call_method<jhobject>(m_object,
+   "setAcceptsDelayedFocusGain", "(Z)Landroid/media/AudioFocusRequest$Builder;", acceptsDelayedFocusGain);
+}
+
+CJNIAudioFocusRequestClassBuilder CJNIAudioFocusRequestClassBuilder::setAudioAttributes(CJNIAudioAttributes attributes)
+{
+  return call_method<jhobject>(m_object,
+   "setAudioAttributes", "(Landroid/media/AudioAttributes;)Landroid/media/AudioFocusRequest$Builder;", attributes.get_raw());
+}
+
+CJNIAudioFocusRequestClassBuilder CJNIAudioFocusRequestClassBuilder::setFocusGain(int focusGain)
+{
+  return call_method<jhobject>(m_object,
+   "setFocusGain", "(I)Landroid/media/AudioFocusRequest$Builder;", focusGain);
+}
+
+CJNIAudioFocusRequestClassBuilder CJNIAudioFocusRequestClassBuilder::setForceDucking(bool forceDucking)
+{
+  return call_method<jhobject>(m_object,
+   "setForceDucking", "(Z)Landroid/media/AudioFocusRequest$Builder;", forceDucking);
+}
+
+CJNIAudioFocusRequestClassBuilder CJNIAudioFocusRequestClassBuilder::setWillPauseWhenDucked(bool pauseOnDuck)
+{
+  return call_method<jhobject>(m_object,
+   "setWillPauseWhenDucked", "(Z)Landroid/media/AudioFocusRequest$Builder;", pauseOnDuck);
+}
+
+CJNIAudioFocusRequestClassBuilder CJNIAudioFocusRequestClassBuilder::setOnAudioFocusChangeListener(const CJNIAudioManagerAudioFocusChangeListener& listener)
+{
+  return call_method<jhobject>(m_object,
+   "setOnAudioFocusChangeListener", "(Landroid/media/AudioManager$OnAudioFocusChangeListener;)Landroid/media/AudioFocusRequest$Builder;", listener.get_raw());
+}

--- a/src/AudioFocusRequest.h
+++ b/src/AudioFocusRequest.h
@@ -1,0 +1,51 @@
+#pragma once
+/*
+ *  Copyright (C) 2021- Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "JNIBase.h"
+
+#include "AudioAttributes.h"
+
+class CJNIAudioManagerAudioFocusChangeListener;
+
+namespace jni
+{
+
+class CJNIAudioFocusRequestClass : public CJNIBase
+{
+public:
+  CJNIAudioFocusRequestClass(const CJNIAudioFocusRequestClass& other) : CJNIBase(other) {}
+  CJNIAudioFocusRequestClass(const jni::jhobject &object) : CJNIBase(object) {}
+
+protected:
+  static const char *m_classname;
+
+};
+
+class CJNIAudioFocusRequestClassBuilder : public CJNIBase
+{
+public:
+  CJNIAudioFocusRequestClassBuilder(int focusgain);
+  CJNIAudioFocusRequestClassBuilder(const CJNIAudioFocusRequestClassBuilder& other) : CJNIBase(other) {}
+  CJNIAudioFocusRequestClassBuilder(const jni::jhobject &object) : CJNIBase(object) {}
+
+  CJNIAudioFocusRequestClass build();
+
+  CJNIAudioFocusRequestClassBuilder setAcceptsDelayedFocusGain(bool acceptsDelayedFocusGain);
+  CJNIAudioFocusRequestClassBuilder setAudioAttributes(CJNIAudioAttributes attributes);
+  CJNIAudioFocusRequestClassBuilder setFocusGain(int focusGain);
+  CJNIAudioFocusRequestClassBuilder setForceDucking(bool forceDucking);
+  CJNIAudioFocusRequestClassBuilder setWillPauseWhenDucked(bool pauseOnDuck);
+
+  CJNIAudioFocusRequestClassBuilder setOnAudioFocusChangeListener(const CJNIAudioManagerAudioFocusChangeListener& listener);
+//  CJNIAudioFocusRequestClassBuilder setOnAudioFocusChangeListener(const CJNIAudioManagerAudioFocusChangeListener& listener, Handler handler)
+
+protected:
+  static const char *m_classname;
+};
+} // namespace jni

--- a/src/AudioManager.cpp
+++ b/src/AudioManager.cpp
@@ -95,6 +95,13 @@ void CJNIAudioManager::setStreamVolume(int index /* 0 */, int flags /* NONE */)
                     STREAM_MUSIC, index, flags);
 }
 
+int CJNIAudioManager::requestAudioFocus(const CJNIAudioFocusRequestClass& request)
+{
+  return call_method<int>(m_object,
+                          "requestAudioFocus",
+                          "(Landroid/media/AudioFocusRequest;)I", request.get_raw());
+}
+
 int CJNIAudioManager::requestAudioFocus(const CJNIAudioManagerAudioFocusChangeListener& listener, int streamType, int durationHint)
 {
   return call_method<int>(m_object,

--- a/src/AudioManager.cpp
+++ b/src/AudioManager.cpp
@@ -109,6 +109,13 @@ int CJNIAudioManager::requestAudioFocus(const CJNIAudioManagerAudioFocusChangeLi
                           "(Landroid/media/AudioManager$OnAudioFocusChangeListener;II)I", listener.get_raw(), streamType, durationHint);
 }
 
+int CJNIAudioManager::abandonAudioFocusRequest(const CJNIAudioFocusRequestClass& request)
+{
+  return call_method<int>(m_object,
+                          "abandonAudioFocusRequest",
+                          "(Landroid/media/AudioFocusRequest;)I", request.get_raw());
+}
+
 int CJNIAudioManager::abandonAudioFocus(const CJNIAudioManagerAudioFocusChangeListener& listener)
 {
   return call_method<int>(m_object,

--- a/src/AudioManager.h
+++ b/src/AudioManager.h
@@ -22,6 +22,7 @@
 #include "JNIBase.h"
 
 #include "AudioDeviceInfo.h"
+#include "AudioFocusRequest.h"
 
 class CJNIAudioManagerAudioFocusChangeListener : virtual public CJNIBase
 {
@@ -41,6 +42,7 @@ public:
   int  getStreamVolume();
   void setStreamVolume(int index = 0, int flags = 0);
 
+  int requestAudioFocus(const jni::CJNIAudioFocusRequestClass& request);
   int requestAudioFocus(const CJNIAudioManagerAudioFocusChangeListener& listener, int streamType, int durationHint);
   int abandonAudioFocus (const CJNIAudioManagerAudioFocusChangeListener& listener);
   bool isBluetoothA2dpOn();

--- a/src/AudioManager.h
+++ b/src/AudioManager.h
@@ -44,6 +44,7 @@ public:
 
   int requestAudioFocus(const jni::CJNIAudioFocusRequestClass& request);
   int requestAudioFocus(const CJNIAudioManagerAudioFocusChangeListener& listener, int streamType, int durationHint);
+  int abandonAudioFocusRequest(const jni::CJNIAudioFocusRequestClass& request);
   int abandonAudioFocus (const CJNIAudioManagerAudioFocusChangeListener& listener);
   bool isBluetoothA2dpOn();
   bool isWiredHeadsetOn();


### PR DESCRIPTION
API 26 deprecated the existing abandonaudiofocus/requestaudiofocus methods

This PR implements the AudiofocusRequestClass + builder for use with the new abandonAudioFocusRequest/requestaudiofocus methods

abandonAudioFocusRequest - https://developer.android.com/reference/android/media/AudioManager#abandonAudioFocusRequest(android.media.AudioFocusRequest)
requestAudioFocus - https://developer.android.com/reference/android/media/AudioManager#requestAudioFocus(android.media.AudioFocusRequest)
AudioFocusRequest - https://developer.android.com/reference/android/media/AudioFocusRequest
AudioFocusRequest.builder - https://developer.android.com/reference/android/media/AudioFocusRequest.Builder

No real reason other than seemed like something i could use to introduce myself to libandroidjni and kodi's usage of it.
Definitely a lot of magic in libandroidjni i definitely dont fully comprehend, so any changes, or advice, happy to take on board.

Have tested on a pixel 3a running Android 11 (API 30) with the appropriate kodi changes. Seems to work ok.