### PR TITLE
Fix undefined reference link errors in setrefreshrate

### DIFF
--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -30,6 +30,8 @@ int CJNISurface::ROTATION_0;
 int CJNISurface::ROTATION_90;
 int CJNISurface::ROTATION_180;
 int CJNISurface::ROTATION_270;
+int CJNISurface::FRAME_RATE_COMPATIBILITY_DEFAULT;
+int CJNISurface::FRAME_RATE_COMPATIBILITY_FIXED_SOURCE;
 const char* CJNISurface::m_classname = "android/view/Surface";
 
 void CJNISurface::PopulateStaticFields()
@@ -39,8 +41,11 @@ void CJNISurface::PopulateStaticFields()
   ROTATION_90 = get_static_field<int>(clazz, "ROTATION_90");
   ROTATION_180= get_static_field<int>(clazz, "ROTATION_180");
   ROTATION_270= get_static_field<int>(clazz, "ROTATION_270");
-  FRAME_RATE_COMPATIBILITY_DEFAULT = get_static_field<int>(clazz, "FRAME_RATE_COMPATIBILITY_DEFAULT");
-  FRAME_RATE_COMPATIBILITY_FIXED_SOURCE = get_static_field<int>(clazz, "FRAME_RATE_COMPATIBILITY_FIXED_SOURCE");
+  if (GetSDKVersion() >= 30)
+  {
+    FRAME_RATE_COMPATIBILITY_DEFAULT = get_static_field<int>(clazz, "FRAME_RATE_COMPATIBILITY_DEFAULT");
+    FRAME_RATE_COMPATIBILITY_FIXED_SOURCE = get_static_field<int>(clazz, "FRAME_RATE_COMPATIBILITY_FIXED_SOURCE");
+  }
 }
 
 CJNISurface::CJNISurface()
@@ -82,7 +87,8 @@ void CJNISurface::unlockCanvas(const CJNICanvas &canvas)
 
 void CJNISurface::setFrameRate(float frameRate, int compatibility)
 {
-  call_method<void>(m_object,"setFrameRate", "(FI)V");
+  if (GetSDKVersion() >= 30)
+    call_method<void>(m_object,"setFrameRate", "(FI)V");
 }
 
 std::string CJNISurface::toString()


### PR DESCRIPTION
I should have build tested Fritsch's work first, my bad. This fixes linking with libandroidjni after the setrefreshrate PR

ints need to be declared in the cpp files
added some guards for api 30 for setrefreshrate calls. This may not be necessary (i think the populatestaticfields will be a requirement), but wasnt sure whether its expected to do the checks in the lib, or in the callee. Either way, cant hurt i guess.