### PR TITLE
MediaCodecInfo: Add Dolby Vision profile constants

### DIFF
--- a/src/MediaCodecInfo.cpp
+++ b/src/MediaCodecInfo.cpp
@@ -108,6 +108,17 @@ int CJNIMediaCodecInfoCodecProfileLevel::AV1ProfileMain10(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AV1ProfileMain10HDR10(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AV1ProfileMain10HDR10Plus(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AV1ProfileMain8(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvav110(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavPen(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavPer(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavSe(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDen(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDer(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtb(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDth(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtr(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheSt(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheStn(0);
 
 const char *CJNIMediaCodecInfoCodecProfileLevel::m_classname = "android/media/MediaCodecInfo$CodecProfileLevel";
 
@@ -201,6 +212,20 @@ void CJNIMediaCodecInfoCodecProfileLevel::PopulateStaticFields()
     VP9Profile2HDR             = (get_static_field<int>(clazz, "VP9Profile2HDR"));
     VP9Profile3                = (get_static_field<int>(clazz, "VP9Profile3"));
     VP9Profile3HDR             = (get_static_field<int>(clazz, "VP9Profile3HDR"));
+    DolbyVisionProfileDvavPen = (get_static_field<int>(clazz, "DolbyVisionProfileDvavPen"));
+    DolbyVisionProfileDvavPer = (get_static_field<int>(clazz, "DolbyVisionProfileDvavPer"));
+    DolbyVisionProfileDvheDen = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDen"));
+    DolbyVisionProfileDvheDer = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDer"));
+    DolbyVisionProfileDvheDtb = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDtb"));
+    DolbyVisionProfileDvheDth = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDth"));
+    DolbyVisionProfileDvheDtr = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDtr"));
+    DolbyVisionProfileDvheStn = (get_static_field<int>(clazz, "DolbyVisionProfileDvheStn"));
+  }
+
+  if (GetSDKVersion >= 27)
+  {
+    DolbyVisionProfileDvavSe = (get_static_field<int>(clazz, "DolbyVisionProfileDvavSe"));
+    DolbyVisionProfileDvheSt = (get_static_field<int>(clazz, "DolbyVisionProfileDvheSt"));
   }
 
   if(GetSDKVersion() >= 29)
@@ -209,6 +234,11 @@ void CJNIMediaCodecInfoCodecProfileLevel::PopulateStaticFields()
     AV1ProfileMain10HDR10      = (get_static_field<int>(clazz, "AV1ProfileMain10HDR10"));
     AV1ProfileMain10HDR10Plus  = (get_static_field<int>(clazz, "AV1ProfileMain10HDR10Plus"));
     AV1ProfileMain8            = (get_static_field<int>(clazz, "AV1ProfileMain8"));
+  }
+
+  if (GetSDKVersion >= 30)
+  {
+    DolbyVisionProfileDvav110 = (get_static_field<int>(clazz, "DolbyVisionProfileDvav110"));
   }
 }
 

--- a/src/MediaCodecInfo.h
+++ b/src/MediaCodecInfo.h
@@ -118,6 +118,17 @@ public:
   static int AV1ProfileMain10HDR10;
   static int AV1ProfileMain10HDR10Plus;
   static int AV1ProfileMain8;
+  static int DolbyVisionProfileDvav110;
+  static int DolbyVisionProfileDvavPen;
+  static int DolbyVisionProfileDvavPer;
+  static int DolbyVisionProfileDvavSe;
+  static int DolbyVisionProfileDvheDen;
+  static int DolbyVisionProfileDvheDer;
+  static int DolbyVisionProfileDvheDtb;
+  static int DolbyVisionProfileDvheDth;
+  static int DolbyVisionProfileDvheDtr;
+  static int DolbyVisionProfileDvheSt;
+  static int DolbyVisionProfileDvheStn;
 
 private:
   CJNIMediaCodecInfoCodecProfileLevel();


### PR DESCRIPTION
Took heavy inspiration from https://github.com/xbmc/libandroidjni/pull/24.
I kept the same order as the Android ref documentation.

This would be useful to better match a decoder, as vendors usually expose a decoder per profile.
Currently untested until I can come up with some patch that makes use of it in Kodi.