### PR TITLE
Implement MediaCodec.CryptoInfo.Pattern

### DIFF
--- a/src/MediaCodec.cpp
+++ b/src/MediaCodec.cpp
@@ -33,6 +33,7 @@ int CJNIMediaCodec::BUFFER_FLAG_END_OF_STREAM(4);
 int CJNIMediaCodec::BUFFER_FLAG_SYNC_FRAME(1);
 int CJNIMediaCodec::CONFIGURE_FLAG_ENCODE(1);
 int CJNIMediaCodec::CONFIGURE_FLAG_DECODE(0);
+int CJNIMediaCodec::CRYPTO_MODE_AES_CBC(2);
 int CJNIMediaCodec::CRYPTO_MODE_AES_CTR(1);
 int CJNIMediaCodec::CRYPTO_MODE_UNENCRYPTED(0);
 int CJNIMediaCodec::INFO_OUTPUT_BUFFERS_CHANGED(-3);
@@ -59,6 +60,10 @@ void CJNIMediaCodec::PopulateStaticFields()
     INFO_TRY_AGAIN_LATER      = (get_static_field<int>(clazz, "INFO_TRY_AGAIN_LATER"));
     VIDEO_SCALING_MODE_SCALE_TO_FIT = (get_static_field<int>(clazz, "VIDEO_SCALING_MODE_SCALE_TO_FIT"));
     VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING = (get_static_field<int>(clazz, "VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING"));
+    if(GetSDKVersion() >= 24)
+    {
+      CRYPTO_MODE_AES_CBC = (get_static_field<int>(clazz, "CRYPTO_MODE_AES_CBC"));
+    }
   }
 }
 

--- a/src/MediaCodec.h
+++ b/src/MediaCodec.h
@@ -65,6 +65,7 @@ public:
   static int BUFFER_FLAG_SYNC_FRAME;
   static int CONFIGURE_FLAG_ENCODE;
   static int CONFIGURE_FLAG_DECODE;
+  static int CRYPTO_MODE_AES_CBC;
   static int CRYPTO_MODE_AES_CTR;
   static int CRYPTO_MODE_UNENCRYPTED;
   static int INFO_OUTPUT_BUFFERS_CHANGED;

--- a/src/MediaCodecCryptoInfo.cpp
+++ b/src/MediaCodecCryptoInfo.cpp
@@ -132,3 +132,13 @@ void CJNIMediaCodecCryptoInfo::set(int newNumSubSamples,
   env->DeleteLocalRef(Key);
   env->DeleteLocalRef(IV);
 }
+
+void CJNIMediaCodecCryptoInfo::setPattern(const CJNIMediaCodecCryptoInfoPattern &pattern)
+{
+  if(GetSDKVersion() >= 24)
+  {
+    call_method<void>(m_object, "setPattern",
+      "(Landroid/media/MediaCodec$CryptoInfo$Pattern;)V",
+      pattern.get_raw());
+  }
+}

--- a/src/MediaCodecCryptoInfo.h
+++ b/src/MediaCodecCryptoInfo.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "JNIBase.h"
+#include "MediaCodecCryptoInfoPattern.h"
 
 class CJNIMediaCodecCryptoInfo : public CJNIBase
 {
@@ -42,4 +43,5 @@ public:
                       const std::vector<char> &newKey,
                       const std::vector<char> &newIV,
                       int newMode);
+  void              setPattern(const CJNIMediaCodecCryptoInfoPattern &pattern);
 };

--- a/src/MediaCodecCryptoInfoPattern.cpp
+++ b/src/MediaCodecCryptoInfoPattern.cpp
@@ -1,0 +1,35 @@
+/*
+ *      Copyright (C) 2022 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "jutils-details.hpp"
+#include "MediaCodecCryptoInfoPattern.h"
+
+using namespace jni;
+
+CJNIMediaCodecCryptoInfoPattern::CJNIMediaCodecCryptoInfoPattern(int blocksToEncrypt,
+                                                                 int blocksToSkip)
+  : CJNIBase("android/media/MediaCodec$CryptoInfo$Pattern")
+{
+  if(GetSDKVersion() >= 24)
+  {
+    m_object = new_object(GetClassName(), "<init>", "(II)V", blocksToEncrypt, blocksToSkip);
+    m_object.setGlobal();
+  }
+}

--- a/src/MediaCodecCryptoInfoPattern.h
+++ b/src/MediaCodecCryptoInfoPattern.h
@@ -1,0 +1,30 @@
+/*
+ *      Copyright (C) 2022 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "JNIBase.h"
+
+class CJNIMediaCodecCryptoInfoPattern : public CJNIBase
+{
+public:
+  CJNIMediaCodecCryptoInfoPattern(int blocksToEncrypt, int blocksToSkip);
+  CJNIMediaCodecCryptoInfoPattern(const jni::jhobject &object) : CJNIBase(object) {}
+  ~CJNIMediaCodecCryptoInfoPattern() {}
+};


### PR DESCRIPTION
Currently AES-CTR is the only encryption scheme supported for inputstreams in Kodi - it's hardcoded. This change allows for CBC encryption scheme to be used with encrypted content, as CBC requires that a pattern of encrypted/skipped blocks (typically 1,9) be supplied to the CryptoInfo object.

Runtime tested (with required changes in Kodi core - PR coming shortly) on Pixel 3.