### PR TITLE
DisplayManager: Fix typo in unregisterDisplayListener.

### DIFF
--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -36,6 +36,6 @@ void CJNIDisplayManager::registerDisplayListener(const jni::jhobject &listener)
 void CJNIDisplayManager::unregisterDisplayListener(const jni::jhobject &listener)
 {
   call_method<void>(m_object,
-    "unregisterDisplayListener", "(Landroid/hardware/display/DisplayManager$DisplayLister;)V",
+    "unregisterDisplayListener", "(Landroid/hardware/display/DisplayManager$DisplayListener;)V",
     listener);
 }


### PR DESCRIPTION
If CJNIDisplayManager::unregisterDisplayListener is called by Kodi (which is currently not the case, but in future it will to fix another bug), a typo in the jni method descriptor string causes "JNI DETECTED ERROR IN APPLICATION: mid == null" followed by abort(), thus forced Kodi exit.