### PR TITLE
Access to the speech recognition service

### DIFF
--- a/src/Bundle.cpp
+++ b/src/Bundle.cpp
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Bundle.h"
+
+#include "jutils-details.hpp"
+
+using namespace jni;
+
+CJNIArrayList<std::string> CJNIBundle::getStringArrayList(const std::string& key)
+{
+  return call_method<jhobject>(m_object, "getStringArrayList",
+    "(Ljava/lang/String;)Ljava/util/ArrayList;", jcast<jhstring>(key));
+}

--- a/src/Bundle.h
+++ b/src/Bundle.h
@@ -1,0 +1,20 @@
+#pragma once
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "JNIBase.h"
+#include "ArrayList.h"
+
+class CJNIBundle : public CJNIBase
+{
+public:
+  CJNIBundle(jni::jhobject const& object) : CJNIBase(object) {};
+  ~CJNIBundle() {};
+
+  CJNIArrayList<std::string> getStringArrayList(const std::string& key);
+};

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -59,6 +59,7 @@
 #include "MediaMetadata.h"
 #include "PlaybackState.h"
 #include "URI.h"
+#include "SpeechRecognizer.h"
 
 #include <android/native_activity.h>
 
@@ -122,6 +123,7 @@ void CJNIContext::PopulateStaticFields()
   CJNIMediaMetadata::PopulateStaticFields();
   CJNIPlaybackState::PopulateStaticFields();
   CJNIURI::PopulateStaticFields();
+  CJNISpeechRecognizer::PopulateStaticFields();
 }
 
 CJNIPackageManager CJNIContext::GetPackageManager()

--- a/src/PackageManager.cpp
+++ b/src/PackageManager.cpp
@@ -28,12 +28,18 @@
 #include "jutils-details.hpp"
 
 using namespace jni;
+
 int CJNIPackageManager::GET_ACTIVITIES(0);
+int CJNIPackageManager::PERMISSION_DENIED;
+int CJNIPackageManager::PERMISSION_GRANTED;
 
 void CJNIPackageManager::PopulateStaticFields()
 {
   jhclass clazz  = find_class("android/content/pm/PackageManager");
-  GET_ACTIVITIES = (get_static_field<int>(clazz, "GET_ACTIVITIES"));
+
+  GET_ACTIVITIES = get_static_field<int>(clazz, "GET_ACTIVITIES");
+  PERMISSION_DENIED = get_static_field<int>(clazz, "PERMISSION_DENIED");
+  PERMISSION_GRANTED = get_static_field<int>(clazz, "PERMISSION_GRANTED");
 }
 
 bool CJNIPackageManager::hasSystemFeature(const std::string &feature)

--- a/src/PackageManager.h
+++ b/src/PackageManager.h
@@ -45,6 +45,8 @@ public:
 
   static void       PopulateStaticFields();
   static int        GET_ACTIVITIES;
+  static int        PERMISSION_DENIED;
+  static int        PERMISSION_GRANTED;
 
 private:
   CJNIPackageManager();

--- a/src/SpeechRecognizer.cpp
+++ b/src/SpeechRecognizer.cpp
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SpeechRecognizer.h"
+
+#include "jutils-details.hpp"
+
+using namespace jni;
+
+static std::string s_className = "android/speech/SpeechRecognizer";
+
+int CJNISpeechRecognizer::ERROR_AUDIO;
+int CJNISpeechRecognizer::ERROR_CLIENT;
+int CJNISpeechRecognizer::ERROR_INSUFFICIENT_PERMISSIONS;
+int CJNISpeechRecognizer::ERROR_NETWORK;
+int CJNISpeechRecognizer::ERROR_NETWORK_TIMEOUT;
+int CJNISpeechRecognizer::ERROR_NO_MATCH;
+int CJNISpeechRecognizer::ERROR_RECOGNIZER_BUSY;
+int CJNISpeechRecognizer::ERROR_SERVER;
+int CJNISpeechRecognizer::ERROR_SPEECH_TIMEOUT;
+std::string CJNISpeechRecognizer::RESULTS_RECOGNITION;
+
+void CJNISpeechRecognizer::PopulateStaticFields()
+{
+  jhclass clazz = find_class(s_className.c_str());
+
+  ERROR_AUDIO =                     get_static_field<int>(clazz, "ERROR_AUDIO");
+  ERROR_CLIENT =                    get_static_field<int>(clazz, "ERROR_CLIENT");
+  ERROR_INSUFFICIENT_PERMISSIONS =  get_static_field<int>(clazz, "ERROR_INSUFFICIENT_PERMISSIONS");
+  ERROR_NETWORK =                   get_static_field<int>(clazz, "ERROR_NETWORK");
+  ERROR_NETWORK_TIMEOUT =           get_static_field<int>(clazz, "ERROR_NETWORK_TIMEOUT");
+  ERROR_NO_MATCH =                  get_static_field<int>(clazz, "ERROR_NO_MATCH");
+  ERROR_RECOGNIZER_BUSY =           get_static_field<int>(clazz, "ERROR_RECOGNIZER_BUSY");
+  ERROR_SERVER =                    get_static_field<int>(clazz, "ERROR_SERVER");
+  ERROR_SPEECH_TIMEOUT =            get_static_field<int>(clazz, "ERROR_SPEECH_TIMEOUT");
+
+  RESULTS_RECOGNITION = jcast<std::string>(get_static_field<jhstring>(clazz, "RESULTS_RECOGNITION"));
+}
+
+bool CJNISpeechRecognizer::isRecognitionAvailable (const CJNIContext& context)
+{
+  return call_static_method<jboolean>(s_className.c_str(), "isRecognitionAvailable",
+    "(Landroid/content/Context;)Z", context.get_raw());
+}
+
+CJNISpeechRecognizer CJNISpeechRecognizer::createSpeechRecognizer(const CJNIContext& context)
+{
+  return call_static_method<jhobject>(s_className.c_str(), "createSpeechRecognizer",
+    "(Landroid/content/Context;)Landroid/speech/SpeechRecognizer;", context.get_raw());
+}
+
+void CJNISpeechRecognizer::setRecognitionListener(const CJNIRecognitionListener& listener)
+{
+  call_method<void>(m_object, "setRecognitionListener", 
+    "(Landroid/speech/RecognitionListener;)V", listener.get_raw());
+}
+
+void CJNISpeechRecognizer::startListening(const CJNIIntent& intent)
+{
+  call_method<void>(m_object, "startListening", "(Landroid/content/Intent;)V", intent.get_raw());
+}

--- a/src/SpeechRecognizer.h
+++ b/src/SpeechRecognizer.h
@@ -1,0 +1,46 @@
+#pragma once
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "JNIBase.h"
+#include "Bundle.h"
+#include "Context.h"
+#include "Intent.h"
+
+class CJNIRecognitionListener : virtual public CJNIBase
+{
+public:
+  virtual void onReadyForSpeech(CJNIBundle bundle) = 0;
+  virtual void onError(int i) = 0;
+  virtual void onResults(CJNIBundle bundle) = 0;
+};
+
+class CJNISpeechRecognizer : public CJNIBase
+{
+public:
+  CJNISpeechRecognizer(const jni::jhobject &object) : CJNIBase(object) {};
+  ~CJNISpeechRecognizer() {};
+  
+  static void PopulateStaticFields();
+  
+  static int ERROR_AUDIO;
+  static int ERROR_CLIENT;
+  static int ERROR_INSUFFICIENT_PERMISSIONS;
+  static int ERROR_NETWORK;
+  static int ERROR_NETWORK_TIMEOUT;
+  static int ERROR_NO_MATCH;
+  static int ERROR_RECOGNIZER_BUSY;
+  static int ERROR_SERVER;
+  static int ERROR_SPEECH_TIMEOUT;
+  static std::string RESULTS_RECOGNITION;
+  
+  static bool isRecognitionAvailable (const CJNIContext& context);
+  static CJNISpeechRecognizer createSpeechRecognizer(const CJNIContext& context);
+  void setRecognitionListener(const CJNIRecognitionListener& listener);
+  void startListening(const CJNIIntent& intent);
+};


### PR DESCRIPTION
Add classes to access the speech recognition service: ```CJNISpeechRecognizer```, ```CJNIRecognitionListener``` and ```CJNIBundle```.

~~Add ```CJNIToast``` to show a brief notifications to the user.~~ 

In ```CJNIContext``` add calls to ```PopulateStaticFields()``` methods.

In ```CJNIPackageManager``` add ```PERMISSION_GRANTED``` and ```PERMISSION_DENIED``` fields.


New classes and changes work perfectly in runtime tests I am doing to incorporate this service in Kodi. 
Tested on Android 9 and 11.