### PR TITLE
Rename CJNIRecognitionListener to CJNISpeechRecognitionListener. 

### DIFF
--- a/src/SpeechRecognizer.cpp
+++ b/src/SpeechRecognizer.cpp
@@ -54,7 +54,7 @@ CJNISpeechRecognizer CJNISpeechRecognizer::createSpeechRecognizer(const CJNICont
     "(Landroid/content/Context;)Landroid/speech/SpeechRecognizer;", context.get_raw());
 }
 
-void CJNISpeechRecognizer::setRecognitionListener(const CJNIRecognitionListener& listener)
+void CJNISpeechRecognizer::setRecognitionListener(const CJNISpeedRecognitionListener& listener)
 {
   call_method<void>(m_object, "setRecognitionListener", 
     "(Landroid/speech/RecognitionListener;)V", listener.get_raw());

--- a/src/SpeechRecognizer.h
+++ b/src/SpeechRecognizer.h
@@ -12,7 +12,7 @@
 #include "Context.h"
 #include "Intent.h"
 
-class CJNIRecognitionListener : virtual public CJNIBase
+class CJNISpeechRecognitionListener : virtual public CJNIBase
 {
 public:
   virtual void onReadyForSpeech(CJNIBundle bundle) = 0;
@@ -41,6 +41,6 @@ public:
   
   static bool isRecognitionAvailable (const CJNIContext& context);
   static CJNISpeechRecognizer createSpeechRecognizer(const CJNIContext& context);
-  void setRecognitionListener(const CJNIRecognitionListener& listener);
+  void setRecognitionListener(const CJNISpeechRecognitionListener& listener);
   void startListening(const CJNIIntent& intent);
 };


### PR DESCRIPTION
We use no namespaces in libandroidjni. So class names should be very specific.