### PR TITLE
Add deprecated info

### DIFF
--- a/src/Activity.h
+++ b/src/Activity.h
@@ -36,6 +36,7 @@ public:
   static CJNIWindowManager getWindowManager();
   static bool moveTaskToBack(bool nonRoot);
   static void startActivityForResult(const CJNIIntent &intent, int requestCode);
+  // Deprecated in API level 26
   static bool requestVisibleBehind(bool visible);
 
   virtual void onVisibleBehindCanceled() = 0;

--- a/src/AudioManager.h
+++ b/src/AudioManager.h
@@ -43,10 +43,14 @@ public:
   void setStreamVolume(int index = 0, int flags = 0);
 
   int requestAudioFocus(const jni::CJNIAudioFocusRequestClass& request);
+  // Deprecated in API level 26
   int requestAudioFocus(const CJNIAudioManagerAudioFocusChangeListener& listener, int streamType, int durationHint);
   int abandonAudioFocusRequest(const jni::CJNIAudioFocusRequestClass& request);
+  // Deprecated in API level 26
   int abandonAudioFocus (const CJNIAudioManagerAudioFocusChangeListener& listener);
+  // Deprecated in API level 26
   bool isBluetoothA2dpOn();
+  // Deprecated in API level 15
   bool isWiredHeadsetOn();
 
   CJNIAudioDeviceInfos getDevices(int flags);

--- a/src/AudioTrack.h
+++ b/src/AudioTrack.h
@@ -35,6 +35,7 @@ namespace jni
 class CJNIAudioTrack : public CJNIBase
 {
   public:
+    // Deprecated in API level 26
     CJNIAudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode) noexcept(false);
     CJNIAudioTrack (const CJNIAudioAttributes &attributes, const CJNIAudioFormat &format, int bufferSizeInBytes, int mode, int sessionId) noexcept(false);
 

--- a/src/BitmapDrawable.h
+++ b/src/BitmapDrawable.h
@@ -28,6 +28,7 @@ class CJNIBitmapDrawable : public CJNIDrawable
 public:
   CJNIBitmapDrawable();
   CJNIBitmapDrawable(const jni::jhobject &object)  : CJNIDrawable(object) {};
+  // This constructor is deprecated
   CJNIBitmapDrawable(const CJNIDrawable &drawable) : CJNIDrawable(drawable.get_raw()) {};
   ~CJNIBitmapDrawable() {};
 

--- a/src/Build.h
+++ b/src/Build.h
@@ -30,14 +30,18 @@ public:
   static std::string PRODUCT;
   static std::string DEVICE;
   static std::string BOARD;
+  // Deprecated in API level 21
   static std::string CPU_ABI;
+  // Deprecated in API level 21
   static std::string CPU_ABI2;
   static std::string MANUFACTURER;
   static std::string BRAND;
   static std::string MODEL;
   static std::string BOOTLOADER;
+  // Deprecated in API level 15
   static std::string RADIO;
   static std::string HARDWARE;
+  // Deprecated in API level 26
   static std::string SERIAL;
   static std::string TYPE;
   static std::string TAGS;

--- a/src/ConnectivityManager.h
+++ b/src/ConnectivityManager.h
@@ -33,31 +33,53 @@ class CJNIConnectivityManager : public CJNIBase
 public:
   CJNIConnectivityManager(const jni::jhobject &object) : CJNIBase(object) {};
 
+  // Deprecated in API level 21
   bool isNetworkTypeValid(int);
+  // Deprecated in API level 21
   void setNetworkPreference(int);
+  // Deprecated in API level 21
   int  getNetworkPreference();
   CJNINetwork getActiveNetwork();
+  // Deprecated in API level 29
   CJNINetworkInfo getActiveNetworkInfo();
+  // Deprecated in API level 23
   CJNINetworkInfo getNetworkInfo(int);
+  // Deprecated in API level 29
   CJNINetworkInfo getNetworkInfo(const CJNINetwork& network);
   CJNILinkProperties getLinkProperties(const CJNINetwork& network);
+  // Deprecated in API level 31
   std::vector<CJNINetwork> getAllNetworks();
+  // Deprecated in API level 23
   std::vector<CJNINetworkInfo> getAllNetworkInfo();
+  // Deprecated in API level 21
   int  startUsingNetworkFeature(int, std::string);
+  // Deprecated in API level 21
   int  stopUsingNetworkFeature(int, std::string);
+  // Deprecated in API level 21
   bool requestRouteToHost(int, int);
+  // Deprecated in API level 15
   bool getBackgroundDataSetting();
 
   static void PopulateStaticFields();
+  // Deprecated in API level 28
   static int TYPE_MOBILE;
+  // Deprecated in API level 28
   static int TYPE_WIFI;
+  // Deprecated in API level 23
   static int TYPE_MOBILE_MMS;
+  // Deprecated in API level 23
   static int TYPE_MOBILE_SUPL;
+  // Deprecated in API level 28
   static int TYPE_MOBILE_DUN;
+  // Deprecated in API level 23
   static int TYPE_MOBILE_HIPRI;
+  // Deprecated in API level 28
   static int TYPE_WIMAX;
+  // Deprecated in API level 28
   static int TYPE_BLUETOOTH;
+  // Deprecated in API level 28
   static int TYPE_DUMMY;
+  // Deprecated in API level 28
   static int TYPE_ETHERNET;
   static int DEFAULT_NETWORK_PREFERENCE;
 

--- a/src/Cursor.h
+++ b/src/Cursor.h
@@ -57,7 +57,9 @@ public:
   double getDouble(int columnIndex);
   int  getType(int columnIndex);
   bool isNull(int columnIndex);
+  // Deprecated in API level 16
   void deactivate();
+  // Deprecated in API level 15
   bool requery();
   void close();
   bool isClosed();

--- a/src/Display.h
+++ b/src/Display.h
@@ -61,9 +61,12 @@ public:
 
   long getAppVsyncOffsetNanos();
   float getRefreshRate();
+  // Deprecated in API level 23
   std::vector<float> getSupportedRefreshRates();
   CJNIDisplayMode getMode();
+  // Deprecated in API level 15
   int getWidth();
+  // Deprecated in API level 15
   int getHeight();
   std::vector<CJNIDisplayMode> getSupportedModes();
   CJNIDisplayHdrCapabilities getHdrCapabilities();

--- a/src/Environment.h
+++ b/src/Environment.h
@@ -31,7 +31,9 @@ public:
   static std::string  MEDIA_MOUNTED;
 
   static std::string  getExternalStorageState();
+  // Deprecated in API level 29
   static CJNIFile     getExternalStorageDirectory();
+  // Deprecated in API level 29
   static CJNIFile     getExternalStoragePublicDirectory(const std::string &type);
 
 protected:

--- a/src/Intent.h
+++ b/src/Intent.h
@@ -41,6 +41,7 @@ public:
 
   int getIntExtra(const std::string &name, int defaultValue) const;
   std::string getStringExtra(const std::string &name) const;
+  // Deprecated in API level 33
   jni::jhobject getParcelableExtra(const std::string &name) const;
 
   bool hasExtra(const std::string &name) const;

--- a/src/MediaCodec.h
+++ b/src/MediaCodec.h
@@ -49,8 +49,10 @@ public:
   void  releaseOutputBuffer(int index, bool render);
   void  releaseOutputBufferAtTime(int index, int64_t renderTimestampNs);
   const CJNIMediaFormat getOutputFormat();
-  std::vector<CJNIByteBuffer> getInputBuffers(); // Deprecated as of API 21
-  std::vector<CJNIByteBuffer> getOutputBuffers(); // Deprecated as of API 21
+  // Deprecated in API level 21
+  std::vector<CJNIByteBuffer> getInputBuffers();
+  // Deprecated in API level 21
+  std::vector<CJNIByteBuffer> getOutputBuffers();
   const CJNIByteBuffer getInputBuffer(int index); // API 21+
   const CJNIByteBuffer getOutputBuffer(int index); // API 21+
   void  setVideoScalingMode(int mode);
@@ -62,12 +64,14 @@ public:
 
   static int BUFFER_FLAG_CODEC_CONFIG;
   static int BUFFER_FLAG_END_OF_STREAM;
+  // Deprecated in API level 21
   static int BUFFER_FLAG_SYNC_FRAME;
   static int CONFIGURE_FLAG_ENCODE;
   static int CONFIGURE_FLAG_DECODE;
   static int CRYPTO_MODE_AES_CBC;
   static int CRYPTO_MODE_AES_CTR;
   static int CRYPTO_MODE_UNENCRYPTED;
+  // Deprecated in API level 21
   static int INFO_OUTPUT_BUFFERS_CHANGED;
   static int INFO_OUTPUT_FORMAT_CHANGED;
   static int INFO_TRY_AGAIN_LATER;

--- a/src/MediaCodecList.h
+++ b/src/MediaCodecList.h
@@ -28,7 +28,9 @@ public:
   CJNIMediaCodecList(const jni::jhobject &object) : CJNIBase(object) {};
   //~CJNIMediaCodecList() {};
 
+  // Deprecated in API level 21
   static int   getCodecCount();
+  // Deprecated in API level 21
   static const CJNIMediaCodecInfo getCodecInfoAt(int index);
 
 private:

--- a/src/MediaDrm.h
+++ b/src/MediaDrm.h
@@ -45,6 +45,7 @@ public:
   CJNIMediaDrm(const CJNIUUID& uuid);
   ~CJNIMediaDrm() {};
 
+  // Deprecated in API level 28
   void release() const;
 
   std::vector<char> openSession() const;

--- a/src/MediaTimestamp.h
+++ b/src/MediaTimestamp.h
@@ -31,6 +31,7 @@ public:
   CJNIMediaTimestamp(const jni::jhobject &object);
 
   int64_t getAnchorMediaTimeUs();
+  // Deprecated in API level 29
   int64_t getAnchorSytemNanoTime();
   float getMediaClockRate();
 };

--- a/src/NetworkInfo.h
+++ b/src/NetworkInfo.h
@@ -42,6 +42,7 @@ private:
   CJNINetworkInfoDetailedState();
 };
 
+// Deprecated in API level 29
 class CJNINetworkInfo : public CJNIBase
 {
 public:

--- a/src/Notification.h
+++ b/src/Notification.h
@@ -52,9 +52,11 @@ public:
   static std::string  EXTRA_BIG_TEXT;
   static std::string  EXTRA_COMPACT_ACTIONS;
   static std::string  EXTRA_INFO_TEXT;
+  // Deprecated in API level 26
   static std::string  EXTRA_LARGE_ICON;
   static std::string  EXTRA_LARGE_ICON_BIG;
   static std::string  EXTRA_MEDIA_SESSION;
+  // Deprecated in API level 28
   static std::string  EXTRA_PEOPLE;
   static std::string  EXTRA_PICTURE;
   static std::string  EXTRA_PROGRESS;
@@ -62,6 +64,7 @@ public:
   static std::string  EXTRA_PROGRESS_MAX;
   static std::string  EXTRA_SHOW_CHRONOMETER;
   static std::string  EXTRA_SHOW_WHEN;
+  // Deprecated in API level 26
   static std::string  EXTRA_SMALL_ICON;
   static std::string  EXTRA_SUB_TEXT;
   static std::string  EXTRA_SUMMARY_TEXT;
@@ -73,19 +76,27 @@ public:
   static int          FLAG_AUTO_CANCEL;
   static int          FLAG_FOREGROUND_SERVICE;
   static int          FLAG_GROUP_SUMMARY;
+  // Deprecated in API level 16
   static int          FLAG_HIGH_PRIORITY;
   static int          FLAG_INSISTENT;
   static int          FLAG_LOCAL_ONLY;
   static int          FLAG_NO_CLEAR;
   static int          FLAG_ONGOING_EVENT;
   static int          FLAG_ONLY_ALERT_ONCE;
+  // Deprecated in API level 26
   static int          FLAG_SHOW_LIGHTS;
   static std::string  INTENT_CATEGORY_NOTIFICATION_PREFERENCES;
+  // Deprecated in API level 26
   static int          PRIORITY_DEFAULT;
+  // Deprecated in API level 26
   static int          PRIORITY_HIGH;
+  // Deprecated in API level 26
   static int          PRIORITY_LOW;
+  // Deprecated in API level 26
   static int          PRIORITY_MAX;
+  // Deprecated in API level 26
   static int          PRIORITY_MIN;
+  // Deprecated in API level 21
   static int          STREAM_DEFAULT;
   static int          VISIBILITY_PRIVATE;
   static int          VISIBILITY_PUBLIC;

--- a/src/Os.h
+++ b/src/Os.h
@@ -32,6 +32,7 @@ public:
   void cancel() const;
   bool hasVibrator() const;
   void vibrate(std::vector<int64_t> pattern, int repeat) const;
+  // Deprecated in API level 26
   void vibrate(int64_t milliseconds) const;
 
 private:

--- a/src/PackageManager.h
+++ b/src/PackageManager.h
@@ -38,6 +38,7 @@ public:
   CJNIIntent        getLaunchIntentForPackage(const std::string &package);
   CJNIIntent        getLeanbackLaunchIntentForPackage(const std::string &package);
   CJNIDrawable      getApplicationIcon(const std::string &package);
+  // Deprecated in API level 33
   CJNIList<CJNIApplicationInfo> getInstalledApplications(int flags);
   CJNICharSequence  getApplicationLabel(const CJNIApplicationInfo &info);
   CJNIResources     getResourcesForApplication(const std::string &package);

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -35,7 +35,9 @@ public:
 
   static void   PopulateStaticFields();
 
+  // Deprecated in API level 17
   static int FULL_WAKE_LOCK;
+  // Deprecated in API level 15
   static int SCREEN_BRIGHT_WAKE_LOCK;
   static int ON_AFTER_RELEASE;
 

--- a/src/Resources.h
+++ b/src/Resources.h
@@ -30,6 +30,7 @@ public:
   CJNIResources(const jni::jhobject &object) : CJNIBase(object) {};
   ~CJNIResources() {};
 
+  // Deprecated in API level 22
   CJNIDrawable      getDrawableForDensity(int id, int density);
 
 private:

--- a/src/ScanResult.h
+++ b/src/ScanResult.h
@@ -30,6 +30,7 @@ public:
   CJNIScanResult(const jni::jhobject &object);
   ~CJNIScanResult(){};
 
+  // Deprecated in API level 33
   std::string SSID;
   std::string BSSID;
   std::string capabilities;

--- a/src/StatFs.h
+++ b/src/StatFs.h
@@ -29,8 +29,11 @@ public:
   ~CJNIStatFs() {};
 
   void  restat(const std::string &path);
+  // Deprecated in API level 18
   int   getBlockSize();
+  // Deprecated in API level 18
   int   getBlockCount();
+  // Deprecated in API level 18
   int   getFreeBlocks();
   int   getAvailableBlocks();
 };

--- a/src/View.h
+++ b/src/View.h
@@ -65,6 +65,7 @@ public:
   int          getProductId() const;
   int          getSources() const;
   int          getVendorId() const;
+  // Deprecated in API level 31
   const CJNIOsVibrator getVibrator() const;
   std::vector<bool> hasKeys(const std::vector<int> &keys) const;
   bool         hasMicrophone() const;

--- a/src/WifiConfiguration.h
+++ b/src/WifiConfiguration.h
@@ -25,6 +25,7 @@
 #include "JNIBase.h"
 #include "BitSet.h"
 
+// Deprecated in API level 29
 class CJNIWifiConfiguration : public CJNIBase
 {
 public:

--- a/src/WifiInfo.h
+++ b/src/WifiInfo.h
@@ -45,6 +45,7 @@ public:
   int         getLinkSpeed()  const;
   std::string getMacAddress() const;
   int         getNetworkId()  const;
+  // Deprecated in API level 31
   int         getIpAddress()  const;
   bool        getHiddenSSID() const;
   std::string toString() const;

--- a/src/WifiManager.h
+++ b/src/WifiManager.h
@@ -34,21 +34,36 @@ friend class CJNIContext;
 public:
   CJNIWifiManager(const jni::jhobject &object) : CJNIBase(object){};
 
+  // Deprecated in API level 29
   CJNIList<CJNIWifiConfiguration> getConfiguredNetworks();
+  // Deprecated in API level 29
   int addNetwork(const CJNIWifiConfiguration &config);
+  // Deprecated in API level 29
   int updateNetwork(const CJNIWifiConfiguration &config);
+  // Deprecated in API level 29
   bool removeNetwork(int);
+  // Deprecated in API level 29
   bool enableNetwork(int, bool);
+  // Deprecated in API level 29
   bool disableNetwork(int);
+  // Deprecated in API level 29
   bool disconnect();
+  // Deprecated in API level 29
   bool reconnect();
+  // Deprecated in API level 29
   bool reassociate();
+  // Deprecated in API level 26
   bool pingSupplicant();
+  // Deprecated in API level 28
   bool startScan();
+  // Deprecated in API level 31
   CJNIWifiInfo getConnectionInfo();
   CJNIList<CJNIScanResult> getScanResults();
+  // Deprecated in API level 26
   bool saveConfiguration();
+  // Deprecated in API level 31
   CJNIDhcpInfo getDhcpInfo();
+  // Deprecated in API level 29
   bool setWifiEnabled(bool);
   int  getWifiState();
   bool isWifiEnabled();


### PR DESCRIPTION
Based on the API documentation I've added the deprecated info in methods and classes where appropriate.

I think it's a good idea to include this info on the library. Allows us to easily identify which methods are deprecated and since when.