### PR TITLE
MediaCodecList: Add getCodecInfos() method

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -60,6 +60,7 @@
 #include "PlaybackState.h"
 #include "URI.h"
 #include "SpeechRecognizer.h"
+#include "MediaCodecList.h"
 
 #include <android/native_activity.h>
 
@@ -124,6 +125,7 @@ void CJNIContext::PopulateStaticFields()
   CJNIPlaybackState::PopulateStaticFields();
   CJNIURI::PopulateStaticFields();
   CJNISpeechRecognizer::PopulateStaticFields();
+  CJNIMediaCodecList::PopulateStaticFields();
 }
 
 CJNIPackageManager CJNIContext::GetPackageManager()

--- a/src/MediaCodecList.cpp
+++ b/src/MediaCodecList.cpp
@@ -27,6 +27,25 @@ using namespace jni;
 
 const char* CJNIMediaCodecList::m_classname = "android/media/MediaCodecList";
 
+int CJNIMediaCodecList::ALL_CODECS;
+int CJNIMediaCodecList::REGULAR_CODECS;
+
+void CJNIMediaCodecList::PopulateStaticFields()
+{
+  jhclass clazz = find_class(m_classname);
+
+  ALL_CODECS = get_static_field<int>(clazz, "ALL_CODECS");
+  REGULAR_CODECS = get_static_field<int>(clazz, "REGULAR_CODECS");
+}
+
+CJNIMediaCodecList::CJNIMediaCodecList(int kind) : CJNIBase(m_classname)
+{
+  m_object = new_object(m_classname,
+    "<init>", "(I)V", kind);
+
+  m_object.setGlobal();
+}
+
 int CJNIMediaCodecList::getCodecCount()
 {
   return call_static_method<int>(m_classname,
@@ -39,3 +58,17 @@ const CJNIMediaCodecInfo CJNIMediaCodecList::getCodecInfoAt(int index)
     "getCodecInfoAt", "(I)Landroid/media/MediaCodecInfo;",
     index);
 }
+
+std::vector<CJNIMediaCodecInfo> CJNIMediaCodecList::getCodecInfos()
+{
+  jhclass clazz = get_class(m_object);
+  jmethodID id = get_method_id(clazz, "getCodecInfos", "()[Landroid/media/MediaCodecInfo;");
+  if (id != NULL)
+    return jcast<CJNIMediaCodecInfos>(call_method<jhobjectArray>(m_object, id));
+  else
+  {
+    xbmc_jnienv()->ExceptionClear();
+    return CJNIMediaCodecInfos();
+  }
+}
+

--- a/src/MediaCodecList.h
+++ b/src/MediaCodecList.h
@@ -26,13 +26,22 @@ class CJNIMediaCodecList : public CJNIBase
 {
 public:
   CJNIMediaCodecList(const jni::jhobject &object) : CJNIBase(object) {};
-  //~CJNIMediaCodecList() {};
+  CJNIMediaCodecList(int kind);
+
+  static void PopulateStaticFields();
+
+  static int ALL_CODECS;
+  static int REGULAR_CODECS;
 
   static int   getCodecCount();
   static const CJNIMediaCodecInfo getCodecInfoAt(int index);
+  std::vector<CJNIMediaCodecInfo> getCodecInfos();
 
 private:
   CJNIMediaCodecList();
 
   static const char *m_classname;
 };
+
+using CJNIMediaCodecInfos = std::vector<CJNIMediaCodecInfo>;
+


### PR DESCRIPTION
```getCodecCount()``` and ```getCodecInfoAt()``` methods of [MediaCodecList](https://developer.android.com/reference/android/media/MediaCodecList) class are deprecated in API level 21.

Add a constructor and the proposed ```getCodecInfos()``` method to use instead.

Runtime tested with required changes in Kodi.