### PR TITLE
Add constants and set feature in MediaFormat

### DIFF
--- a/src/MediaFormat.cpp
+++ b/src/MediaFormat.cpp
@@ -41,11 +41,41 @@ std::string CJNIMediaFormat::KEY_CHANNEL_MASK;
 std::string CJNIMediaFormat::KEY_AAC_PROFILE;
 std::string CJNIMediaFormat::KEY_FLAC_COMPRESSION_LEVEL;
 std::string CJNIMediaFormat::KEY_ROTATION;
+std::string CJNIMediaFormat::KEY_COLOR_RANGE;
+std::string CJNIMediaFormat::KEY_COLOR_STANDARD;
+std::string CJNIMediaFormat::KEY_COLOR_TRANSFER;
+std::string CJNIMediaFormat::KEY_CROP_BOTTOM;
+std::string CJNIMediaFormat::KEY_CROP_LEFT;
+std::string CJNIMediaFormat::KEY_CROP_RIGHT;
+std::string CJNIMediaFormat::KEY_CROP_TOP;
+std::string CJNIMediaFormat::KEY_HDR_STATIC_INFO;
+std::string CJNIMediaFormat::KEY_SLICE_HEIGHT;
+std::string CJNIMediaFormat::KEY_STRIDE;
+
+int CJNIMediaFormat::COLOR_STANDARD_BT2020;
+int CJNIMediaFormat::COLOR_STANDARD_BT709;
+int CJNIMediaFormat::COLOR_TRANSFER_HLG;
+int CJNIMediaFormat::COLOR_TRANSFER_LINEAR;
+int CJNIMediaFormat::COLOR_TRANSFER_SDR_VIDEO;
+int CJNIMediaFormat::COLOR_TRANSFER_ST2084;
+
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_AV1;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_AVC;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_DOLBY_VISION;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_H263;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_HEVC;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_MPEG2;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_MPEG4;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_RAW;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_SCRAMBLED;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_VP8;
+std::string CJNIMediaFormat::MIMETYPE_VIDEO_VP9;
+
 const char *CJNIMediaFormat::m_classname = "android/media/MediaFormat";
 
 void CJNIMediaFormat::PopulateStaticFields()
 {
-  if(GetSDKVersion() >= 16)
+  if (GetSDKVersion() >= 16)
   {
     jhclass clazz = find_class("android/media/MediaFormat");
     KEY_MIME            = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_MIME"));
@@ -64,9 +94,56 @@ void CJNIMediaFormat::PopulateStaticFields()
     KEY_AAC_PROFILE     = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_AAC_PROFILE"));
     KEY_FLAC_COMPRESSION_LEVEL = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_FLAC_COMPRESSION_LEVEL"));
 
-    if(GetSDKVersion() >= 23)
+    if (GetSDKVersion() >= 21)
+    {
+      MIMETYPE_VIDEO_AVC = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_AVC"));
+      MIMETYPE_VIDEO_H263 = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_H263"));
+      MIMETYPE_VIDEO_HEVC = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_HEVC"));
+      MIMETYPE_VIDEO_MPEG2 = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_MPEG2"));
+      MIMETYPE_VIDEO_MPEG4 = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_MPEG4"));
+      MIMETYPE_VIDEO_RAW = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_RAW"));
+      MIMETYPE_VIDEO_VP8 = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_VP8"));
+      MIMETYPE_VIDEO_VP9 = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_VP9"));
+    }
+
+    if (GetSDKVersion() >= 23)
     {
       KEY_ROTATION = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_ROTATION"));
+      KEY_SLICE_HEIGHT = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_SLICE_HEIGHT"));
+      KEY_STRIDE = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_STRIDE"));
+    }
+
+    if (GetSDKVersion() >= 24)
+    {
+      COLOR_STANDARD_BT2020 = (get_static_field<int>(clazz, "COLOR_STANDARD_BT2020"));
+      COLOR_STANDARD_BT709 = (get_static_field<int>(clazz, "COLOR_STANDARD_BT709"));
+      COLOR_TRANSFER_HLG = (get_static_field<int>(clazz, "COLOR_TRANSFER_HLG"));
+      COLOR_TRANSFER_LINEAR = (get_static_field<int>(clazz, "COLOR_TRANSFER_LINEAR"));
+      COLOR_TRANSFER_SDR_VIDEO = (get_static_field<int>(clazz, "COLOR_TRANSFER_SDR_VIDEO"));
+      COLOR_TRANSFER_ST2084 = (get_static_field<int>(clazz, "COLOR_TRANSFER_ST2084"));
+      KEY_COLOR_RANGE = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_COLOR_RANGE"));
+      KEY_COLOR_STANDARD = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_COLOR_STANDARD"));
+      KEY_COLOR_TRANSFER = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_COLOR_TRANSFER"));
+      KEY_HDR_STATIC_INFO = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_HDR_STATIC_INFO"));
+      MIMETYPE_VIDEO_DOLBY_VISION = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_DOLBY_VISION"));
+    }
+
+    if (GetSDKVersion() >= 26)
+    {
+      MIMETYPE_VIDEO_SCRAMBLED = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_SCRAMBLED"));
+    }
+
+    if (GetSDKVersion() >= 29)
+    {
+      MIMETYPE_VIDEO_AV1 = jcast<std::string>(get_static_field<jhstring>(clazz, "MIMETYPE_VIDEO_AV1"));
+    }
+
+    if (GetSDKVersion() >= 33)
+    {
+      KEY_CROP_BOTTOM = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_CROP_BOTTOM"));
+      KEY_CROP_LEFT = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_CROP_LEFT"));
+      KEY_CROP_RIGHT = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_CROP_RIGHT"));
+      KEY_CROP_TOP = jcast<std::string>(get_static_field<jhstring>(clazz, "KEY_CROP_TOP"));
     }
   }
 }
@@ -129,39 +206,53 @@ const CJNIByteBuffer CJNIMediaFormat::getByteBuffer(const std::string &name)
     jcast<jhstring>(name));
 }
 
-void  CJNIMediaFormat::setInteger(const std::string &name, int value)
+bool CJNIMediaFormat::getFeatureEnabled(const std::string& feature)
+{
+  return call_method<jboolean>(m_object,
+    "getFeatureEnabled", "(Ljava/lang/String;)Z",
+    jcast<jhstring>(feature));
+}
+
+void CJNIMediaFormat::setInteger(const std::string &name, int value)
 {
   call_method<void>(m_object,
     "setInteger", "(Ljava/lang/String;I)V",
     jcast<jhstring>(name), value);
 }
 
-void  CJNIMediaFormat::setLong(const std::string &name, int64_t value)
+void CJNIMediaFormat::setLong(const std::string &name, int64_t value)
 {
   call_method<void>(m_object,
     "setLong", "(Ljava/lang/String;J)V",
     jcast<jhstring>(name), value);
 }
 
-void  CJNIMediaFormat::setFloat(const std::string &name, float value)
+void CJNIMediaFormat::setFloat(const std::string &name, float value)
 {
   call_method<void>(m_object,
     "setFloat", "(Ljava/lang/String;F)V",
     jcast<jhstring>(name), value);
 }
 
-void  CJNIMediaFormat::setString(const std::string &name,const std::string &value)
+void CJNIMediaFormat::setString(const std::string &name,const std::string &value)
 {
   call_method<void>(m_object,
     "setString", "(Ljava/lang/String;Ljava/lang/String;)V",
     jcast<jhstring>(name), jcast<jhstring>(value));
 }
 
-void  CJNIMediaFormat::setByteBuffer(const std::string &name, CJNIByteBuffer &bytes)
+void CJNIMediaFormat::setByteBuffer(const std::string &name, CJNIByteBuffer &bytes)
 {
   call_method<void>(m_object,
     "setByteBuffer", "(Ljava/lang/String;Ljava/nio/ByteBuffer;)V",
     jcast<jhstring>(name), bytes.get_raw());
+}
+
+void CJNIMediaFormat::setFeatureEnabled (const std::string& feature, bool enabled)
+{
+  call_method<void>(m_object,
+    "setFeatureEnabled", "(Ljava/lang/String;Z)V",
+    jcast<jhstring>(feature), enabled);
 }
 
 std::string CJNIMediaFormat::toString() const

--- a/src/MediaFormat.h
+++ b/src/MediaFormat.h
@@ -34,12 +34,15 @@ public:
   float       getFloat(   const std::string &name);
   std::string getString(  const std::string &name);
   const       CJNIByteBuffer getByteBuffer(const std::string &name);
+  bool        getFeatureEnabled (const std::string& feature);
   void        setInteger( const std::string &name, int     value);
   void        setLong(    const std::string &name, int64_t value);
   void        setFloat(   const std::string &name, float   value);
   void        setString(  const std::string &name, const std::string &value);
   void        setByteBuffer(const std::string &name, CJNIByteBuffer &bytes);
+  void        setFeatureEnabled (const std::string& feature, bool enabled);
   std::string toString()  const;
+
 
   static void  PopulateStaticFields();
   static const CJNIMediaFormat createAudioFormat(const std::string &mime, int sampleRate, int channelCount);
@@ -61,6 +64,35 @@ public:
   static std::string KEY_AAC_PROFILE;
   static std::string KEY_FLAC_COMPRESSION_LEVEL;
   static std::string KEY_ROTATION;
+  static std::string KEY_COLOR_RANGE;
+  static std::string KEY_COLOR_STANDARD;
+  static std::string KEY_COLOR_TRANSFER;
+  static std::string KEY_CROP_BOTTOM;
+  static std::string KEY_CROP_LEFT;
+  static std::string KEY_CROP_RIGHT;
+  static std::string KEY_CROP_TOP;
+  static std::string KEY_HDR_STATIC_INFO;
+  static std::string KEY_SLICE_HEIGHT;
+  static std::string KEY_STRIDE;
+
+  static int COLOR_STANDARD_BT2020;
+  static int COLOR_STANDARD_BT709;
+  static int COLOR_TRANSFER_HLG;
+  static int COLOR_TRANSFER_LINEAR;
+  static int COLOR_TRANSFER_SDR_VIDEO;
+  static int COLOR_TRANSFER_ST2084;
+
+  static std::string MIMETYPE_VIDEO_AV1;
+  static std::string MIMETYPE_VIDEO_AVC;
+  static std::string MIMETYPE_VIDEO_DOLBY_VISION;
+  static std::string MIMETYPE_VIDEO_H263;
+  static std::string MIMETYPE_VIDEO_HEVC;
+  static std::string MIMETYPE_VIDEO_MPEG2;
+  static std::string MIMETYPE_VIDEO_MPEG4;
+  static std::string MIMETYPE_VIDEO_RAW;
+  static std::string MIMETYPE_VIDEO_SCRAMBLED;
+  static std::string MIMETYPE_VIDEO_VP8;
+  static std::string MIMETYPE_VIDEO_VP9;
 
 private:
   CJNIMediaFormat();


### PR DESCRIPTION
Add the MediaFormat constants that are being used directly by value in Kodi.

Add the [setFeatureEnabled()](https://developer.android.com/reference/android/media/MediaFormat#setFeatureEnabled(java.lang.String,%20boolean)) method to request a feature to be present or not. Also the [getFeatureEnabled()](https://developer.android.com/reference/android/media/MediaFormat#getFeatureEnabled(java.lang.String)) method if needed.