### PR TITLE
Add the FLAG_KEEP_SCREEN_ON flag

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -61,6 +61,7 @@
 #include "URI.h"
 #include "SpeechRecognizer.h"
 #include "MediaCodecList.h"
+#include "WindowManager.h"
 
 #include <android/native_activity.h>
 
@@ -126,6 +127,7 @@ void CJNIContext::PopulateStaticFields()
   CJNIURI::PopulateStaticFields();
   CJNISpeechRecognizer::PopulateStaticFields();
   CJNIMediaCodecList::PopulateStaticFields();
+  CJNIWindowManagerLayoutParams::PopulateStaticFields();
 }
 
 CJNIPackageManager CJNIContext::GetPackageManager()

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -60,3 +60,13 @@ void CJNIWindow::setCallback(const jni::jhobject &object)
   call_method<void>(m_object,
     "setCallback", "(Landroid/view/Window$Callback;)V", object);
 }
+
+void CJNIWindow::addFlags(int flags)
+{
+  call_method<void>(m_object, "addFlags", "(I)V", flags);
+}
+
+void CJNIWindow::clearFlags(int flags)
+{
+  call_method<void>(m_object, "clearFlags", "(I)V", flags);
+}

--- a/src/Window.h
+++ b/src/Window.h
@@ -36,4 +36,7 @@ public:
   void setCallback(const jni::jhobject &object);
 
   CJNIView getDecorView();
+
+  void addFlags (int flags);
+  void clearFlags (int flags);
 };

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -31,6 +31,14 @@ CJNIDisplay CJNIWindowManager::getDefaultDisplay()
     "getDefaultDisplay", "()Landroid/view/Display;");
 }
 
+int CJNIWindowManagerLayoutParams::FLAG_KEEP_SCREEN_ON;
+
+void CJNIWindowManagerLayoutParams::PopulateStaticFields()
+{
+  jhclass clazz = find_class("android/view/WindowManager$LayoutParams");
+  FLAG_KEEP_SCREEN_ON = (get_static_field<int>(clazz, "FLAG_KEEP_SCREEN_ON"));
+}
+
 float CJNIWindowManagerLayoutParams::getpreferredRefreshRate() const
 {
   if (GetSDKVersion() >= 21)

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -42,4 +42,7 @@ public:
   void setpreferredRefreshRate(float rate);
   int getpreferredDisplayModeId() const;
   void setpreferredDisplayModeId(int modeid);
+
+  static void PopulateStaticFields();
+  static int FLAG_KEEP_SCREEN_ON;
 };


### PR DESCRIPTION
Add the [FLAG_KEEP_SCREEN_ON](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_KEEP_SCREEN_ON) flag and the necessary methods.

The idea is to use this flag to keep the screen active instead of using a wakelock.