### PR TITLE
Only retrieve the result if the MediaDrm method does not throw an exc…

### DIFF
--- a/src/MediaDrm.cpp
+++ b/src/MediaDrm.cpp
@@ -41,6 +41,11 @@ void CJNIMediaDrm::release() const
     "release", "()V");
 }
 
+void CJNIMediaDrm::close() const
+{
+  call_method<void>(m_object, "close", "()V");
+}
+
 std::vector<char> CJNIMediaDrm::openSession() const
 {
   JNIEnv *env = xbmc_jnienv();
@@ -160,11 +165,14 @@ std::vector<char> CJNIMediaDrm::provideKeyResponse(const std::vector<char> &scop
   jhbyteArray array = call_method<jhbyteArray>(m_object,
     "provideKeyResponse", "([B[B)[B", scope_, response_);
 
-  size = env->GetArrayLength(array.get());
-
   std::vector<char> result;
-  result.resize(size);
-  env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+
+  if (!env->ExceptionCheck())
+  {
+    jsize size = env->GetArrayLength(array.get());
+    result.resize(size);
+    env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+  }
 
   env->DeleteLocalRef(scope_);
   env->DeleteLocalRef(response_);

--- a/src/MediaDrm.h
+++ b/src/MediaDrm.h
@@ -47,6 +47,7 @@ public:
 
   // Deprecated in API level 28
   void release() const;
+  void close() const;
 
   std::vector<char> openSession() const;
   void closeSession(const std::vector<char> & sessionId) const;

--- a/src/MediaDrmCryptoSession.cpp
+++ b/src/MediaDrmCryptoSession.cpp
@@ -26,22 +26,57 @@ using namespace jni;
 
 std::vector<char> CJNIMediaDrmCryptoSession::decrypt(const std::vector<char> &keyid, const std::vector<char> &input, const std::vector<char> &iv) const
 {
-  return jcast<std::vector<char> >(call_method<jhbyteArray>(m_object,
-    "decrypt", "([B[B[B)[B", jcast<jhbyteArray>(keyid), jcast<jhbyteArray>(input), jcast<jhbyteArray>(iv)));
+  JNIEnv* env = xbmc_jnienv();
+  jhbyteArray array = call_method<jhbyteArray>(m_object,
+    "decrypt", "([B[B[B)[B", jcast<jhbyteArray>(keyid), jcast<jhbyteArray>(input), jcast<jhbyteArray>(iv));
+
+  std::vector<char> result;
+
+  if (!env->ExceptionCheck())
+  {
+    jsize size = env->GetArrayLength(array.get());
+    result.resize(size);
+    env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+  }
+
+  return result;
 }
 
 std::vector<char> CJNIMediaDrmCryptoSession::encrypt(const std::vector<char> &keyid, const std::vector<char> &input, const std::vector<char> &iv) const
 {
-  return jcast<std::vector<char> >(call_method<jhbyteArray>(m_object,
-    "encrypt", "([B[B[B)[B", jcast<jhbyteArray>(keyid), jcast<jhbyteArray>(input), jcast<jhbyteArray>(iv)));
+  JNIEnv* env = xbmc_jnienv();
+  jhbyteArray array = call_method<jhbyteArray>(m_object,
+    "encrypt", "([B[B[B)[B", jcast<jhbyteArray>(keyid), jcast<jhbyteArray>(input), jcast<jhbyteArray>(iv));
+
+  std::vector<char> result;
+
+  if (!env->ExceptionCheck())
+  {
+    jsize size = env->GetArrayLength(array.get());
+    result.resize(size);
+    env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+  }
+
+  return result;
 }
 
 std::vector<char> CJNIMediaDrmCryptoSession::sign(const std::vector<char> &keyid, const std::vector<char> &message) const
 {
-  return jcast<std::vector<char> >(call_method<jhbyteArray>(m_object,
-    "sign", "([B[B)[B", jcast<jhbyteArray>(keyid), jcast<jhbyteArray>(message)));
-}
+  JNIEnv* env = xbmc_jnienv();
+  jhbyteArray array = call_method<jhbyteArray>(m_object,
+    "sign", "([B[B)[B", jcast<jhbyteArray>(keyid), jcast<jhbyteArray>(message));
 
+  std::vector<char> result;
+
+  if (!env->ExceptionCheck())
+  {
+    jsize size = env->GetArrayLength(array.get());
+    result.resize(size);
+    env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+  }
+
+  return result;
+}
 
 bool CJNIMediaDrmCryptoSession::verify(const std::vector<char> &keyid, const std::vector<char> &message, const std::vector<char> &signature) const
 {

--- a/src/MediaDrmKeyRequest.cpp
+++ b/src/MediaDrmKeyRequest.cpp
@@ -36,11 +36,14 @@ std::vector<char> CJNIMediaDrmKeyRequest::getData() const
   jhbyteArray array = call_method<jhbyteArray>(m_object,
     "getData", "()[B");
 
-  jsize size = env->GetArrayLength(array.get());
-
   std::vector<char> result;
-  result.resize(size);
-  env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+
+  if (!env->ExceptionCheck())
+  {
+    jsize size = env->GetArrayLength(array.get());
+    result.resize(size);
+    env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+  }
 
   return result;
 }

--- a/src/MediaDrmProvisionRequest.cpp
+++ b/src/MediaDrmProvisionRequest.cpp
@@ -36,11 +36,14 @@ std::vector<char> CJNIMediaDrmProvisionRequest::getData() const
   jhbyteArray array = call_method<jhbyteArray>(m_object,
     "getData", "()[B");
 
-  jsize size = env->GetArrayLength(array.get());
-
   std::vector<char> result;
-  result.resize(size);
-  env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+
+  if (!env->ExceptionCheck())
+  {
+    jsize size = env->GetArrayLength(array.get());
+    result.resize(size);
+    env->GetByteArrayRegion(array.get(), 0, size, (jbyte*)result.data());
+  }
 
   return result;
 }


### PR DESCRIPTION
…eption

Before retrieve the result of a JNI method we must check if it has thrown an exception. 

Example of exceptions thrown when calling the `encrypt()` method:
```
Pending exception android.media.MediaDrm$MediaDrmStateException: Failed to encrypt: Session not opened
  at byte[] android.media.MediaDrm.encryptNative(android.media.MediaDrm, byte[], byte[], byte[], byte[]) (MediaDrm.java:-2)
  at byte[] android.media.MediaDrm.access$300(android.media.MediaDrm, byte[], byte[], byte[], byte[]) (MediaDrm.java:135)
  at byte[] android.media.MediaDrm$CryptoSession.encrypt(byte[], byte[], byte[]) (MediaDrm.java:1781)

JNI DETECTED ERROR IN APPLICATION: java_array == null
    in call to GetPrimitiveArray
--------- beginning of crash
```


Also add `close()` method which replaces `release()` method.