### PR TITLE
Add Resources.getDrawableForDensity method

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -62,6 +62,7 @@
 #include "SpeechRecognizer.h"
 #include "MediaCodecList.h"
 #include "WindowManager.h"
+#include "Resources.h"
 
 #include <android/native_activity.h>
 
@@ -245,4 +246,9 @@ CJNIWindow CJNIContext::getWindow()
 {
   return call_method<jhobject>(m_context,
     "getWindow", "()Landroid/view/Window;");
+}
+
+CJNIResourcesTheme CJNIContext::getTheme()
+{
+  return call_method<jhobject>(m_context, "getTheme", "()Landroid/content/res/Resources$Theme;");
 }

--- a/src/Context.h
+++ b/src/Context.h
@@ -32,6 +32,7 @@ class CJNIApplicationInfo;
 class CJNIFile;
 class CJNIContentResolver;
 class CJNIWindow;
+class CJNIResourcesTheme;
 
 class CJNIContext
 {
@@ -60,6 +61,7 @@ public:
   static CJNIFile getExternalFilesDir(const std::string &path);
   static CJNIContentResolver getContentResolver();
   static CJNIWindow getWindow();
+  static CJNIResourcesTheme getTheme();
 
 protected:
   CJNIContext(const ANativeActivity *nativeActivity);

--- a/src/Resources.cpp
+++ b/src/Resources.cpp
@@ -31,3 +31,10 @@ CJNIDrawable CJNIResources::getDrawableForDensity(int id, int density)
     id, density);
 }
 
+CJNIDrawable CJNIResources::getDrawableForDensity(int id, int density, const CJNIResourcesTheme& theme)
+{
+  return call_method<jhobject>(m_object,
+    "getDrawableForDensity",
+    "(IILandroid/content/res/Resources$Theme;)Landroid/graphics/drawable/Drawable;",
+    id, density, theme.get_raw());
+}

--- a/src/Resources.h
+++ b/src/Resources.h
@@ -20,9 +20,9 @@
  */
 
 #include "JNIBase.h"
-#include "List.h"
 
 class CJNIDrawable;
+class CJNIResourcesTheme;
 
 class CJNIResources : public CJNIBase
 {
@@ -31,8 +31,16 @@ public:
   ~CJNIResources() {};
 
   // Deprecated in API level 22
-  CJNIDrawable      getDrawableForDensity(int id, int density);
+  CJNIDrawable getDrawableForDensity(int id, int density);
+  CJNIDrawable getDrawableForDensity(int id, int density, const CJNIResourcesTheme& theme);
 
 private:
   CJNIResources();
+};
+
+class CJNIResourcesTheme : public CJNIBase
+{
+public:
+  CJNIResourcesTheme(const jni::jhobject& object) : CJNIBase(object) {};
+  ~CJNIResourcesTheme() {};
 };


### PR DESCRIPTION
Add `getDrawableForDensity(int id, int density, Resources.Theme theme)` method to replace 
 `getDrawableForDensity(int id, int density)` deprecated in API level 22.

This method returns a drawable object associated with a resource ID for the given screen density in DPI and styled for the specified theme.

Add also the `Resources.Theme` class and the `Context.getTheme()` method.

Checked that it works correctly in Kodi