### PR TITLE
Add functions to allow obtaining specific views, and setting background color

### DIFF
--- a/src/Activity.cpp
+++ b/src/Activity.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "Activity.h"
+#include "View.h"
 #include "Intent.h"
 #include "WindowManager.h"
 
@@ -61,5 +62,11 @@ bool CJNIActivity::requestVisibleBehind(bool visible)
   return call_method<jboolean>(m_context,
     "requestVisibleBehind", "(Z)Z",
                                visible);
+}
+
+CJNIView CJNIActivity::findViewById(const int id)
+{
+  return call_method<jhobject>(m_context,
+    "findViewById", "(I)Landroid/view/View;", id);
 }
 

--- a/src/Activity.h
+++ b/src/Activity.h
@@ -25,6 +25,8 @@
 
 class CJNIWindowManager;
 class CVariant;
+class CJNIView;
+
 struct ANativeActivity;
 
 class CJNIActivity : public CJNIContext
@@ -38,6 +40,7 @@ public:
   static void startActivityForResult(const CJNIIntent &intent, int requestCode);
   // Deprecated in API level 26
   static bool requestVisibleBehind(bool visible);
+  static CJNIView findViewById(const int id);
 
   virtual void onVisibleBehindCanceled() = 0;
 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -252,3 +252,9 @@ CJNIResourcesTheme CJNIContext::getTheme()
 {
   return call_method<jhobject>(m_context, "getTheme", "()Landroid/content/res/Resources$Theme;");
 }
+
+CJNIResources CJNIContext::getResources()
+{
+  return call_method<jhobject>(m_context,
+    "getResources", "()Landroid/content/res/Resources;");
+}

--- a/src/Context.h
+++ b/src/Context.h
@@ -33,6 +33,7 @@ class CJNIFile;
 class CJNIContentResolver;
 class CJNIWindow;
 class CJNIResourcesTheme;
+class CJNIResources;
 
 class CJNIContext
 {
@@ -62,6 +63,7 @@ public:
   static CJNIContentResolver getContentResolver();
   static CJNIWindow getWindow();
   static CJNIResourcesTheme getTheme();
+  static CJNIResources getResources();
 
 protected:
   CJNIContext(const ANativeActivity *nativeActivity);

--- a/src/Resources.cpp
+++ b/src/Resources.cpp
@@ -38,3 +38,13 @@ CJNIDrawable CJNIResources::getDrawableForDensity(int id, int density, const CJN
     "(IILandroid/content/res/Resources$Theme;)Landroid/graphics/drawable/Drawable;",
     id, density, theme.get_raw());
 }
+
+int CJNIResources::getIdentifier(const std::string &name,
+                                 const std::string &type,
+                                 const std::string &package)
+{
+  return call_method<int>(m_object,
+    "getIdentifier",
+    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I",
+    jcast<jhstring>(name), jcast<jhstring>(type), jcast<jhstring>(package));
+}

--- a/src/Resources.h
+++ b/src/Resources.h
@@ -33,6 +33,8 @@ public:
   // Deprecated in API level 22
   CJNIDrawable getDrawableForDensity(int id, int density);
   CJNIDrawable getDrawableForDensity(int id, int density, const CJNIResourcesTheme& theme);
+  
+  int getIdentifier(const std::string &name, const std::string &type, const std::string &package);
 
 private:
   CJNIResources();

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -309,3 +309,9 @@ CJNIDisplay CJNIView::getDisplay()
   else
     return jhobject();
 }
+
+void CJNIView::setBackgroundColor(const int color)
+{
+  call_method<void>(m_object,
+    "setBackgroundColor", "(I)V", color);
+}

--- a/src/View.h
+++ b/src/View.h
@@ -116,6 +116,8 @@ public:
   int	 getSystemUiVisibility();
   CJNIDisplay getDisplay();
 
+  void setBackgroundColor(const int color);
+
   static void PopulateStaticFields();
   static int SYSTEM_UI_FLAG_FULLSCREEN;
   static int SYSTEM_UI_FLAG_HIDE_NAVIGATION;


### PR DESCRIPTION
Supercedes https://github.com/xbmc/libandroidjni/pull/42.
Let me know if I should close the other.

This PR contains the same `CJNIView::setBackgroundColor` and more.
This would allow for Kodi to find `View` objects by the resource name or ID.

Tested and it works.
I'll add the relevant changes to https://github.com/xbmc/xbmc/pull/22561

Or if we decide to simply just revert, this is example code: https://github.com/quietvoid/xbmc/commit/9e455a119ecab38a93163b6f7a3d3ec83184b016