### PR TITLE
Add HEVC profile constants in MediaCodecInfo

### DIFF
--- a/src/MediaCodecInfo.cpp
+++ b/src/MediaCodecInfo.cpp
@@ -47,6 +47,17 @@ int CJNIMediaCodecInfoCodecProfileLevel::AVCLevel41(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AVCLevel42(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AVCLevel5(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AVCLevel51(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvav110(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavPen(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavPer(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavSe(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDen(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDer(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtb(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDth(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtr(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheSt(0);
+int CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheStn(0);
 int CJNIMediaCodecInfoCodecProfileLevel::H263ProfileBaseline(0);
 int CJNIMediaCodecInfoCodecProfileLevel::H263ProfileH320Coding(0);
 int CJNIMediaCodecInfoCodecProfileLevel::H263ProfileBackwardCompatible(0);
@@ -208,6 +219,14 @@ void CJNIMediaCodecInfoCodecProfileLevel::PopulateStaticFields()
 
   if(GetSDKVersion() >= 24)
   {
+    DolbyVisionProfileDvavPen  = (get_static_field<int>(clazz, "DolbyVisionProfileDvavPen"));
+    DolbyVisionProfileDvavPer  = (get_static_field<int>(clazz, "DolbyVisionProfileDvavPer"));
+    DolbyVisionProfileDvheDen  = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDen"));
+    DolbyVisionProfileDvheDer  = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDer"));
+    DolbyVisionProfileDvheDtb  = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDtb"));
+    DolbyVisionProfileDvheDth  = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDth"));
+    DolbyVisionProfileDvheDtr  = (get_static_field<int>(clazz, "DolbyVisionProfileDvheDtr"));
+    DolbyVisionProfileDvheStn  = (get_static_field<int>(clazz, "DolbyVisionProfileDvheStn"));
     HEVCProfileMain10HDR10     = (get_static_field<int>(clazz, "HEVCProfileMain10HDR10"));
     VP9Profile0                = (get_static_field<int>(clazz, "VP9Profile0"));
     VP9Profile1                = (get_static_field<int>(clazz, "VP9Profile1"));
@@ -215,6 +234,12 @@ void CJNIMediaCodecInfoCodecProfileLevel::PopulateStaticFields()
     VP9Profile2HDR             = (get_static_field<int>(clazz, "VP9Profile2HDR"));
     VP9Profile3                = (get_static_field<int>(clazz, "VP9Profile3"));
     VP9Profile3HDR             = (get_static_field<int>(clazz, "VP9Profile3HDR"));
+  }
+
+  if(GetSDKVersion() >= 27)
+  {
+    DolbyVisionProfileDvavSe   = (get_static_field<int>(clazz, "DolbyVisionProfileDvavSe"));
+    DolbyVisionProfileDvheSt   = (get_static_field<int>(clazz, "DolbyVisionProfileDvheSt"));
   }
 
   if(GetSDKVersion() >= 28)
@@ -231,6 +256,11 @@ void CJNIMediaCodecInfoCodecProfileLevel::PopulateStaticFields()
     HEVCProfileMain10HDR10Plus = (get_static_field<int>(clazz, "HEVCProfileMain10HDR10Plus"));
     VP9Profile2HDR10Plus       = (get_static_field<int>(clazz, "VP9Profile2HDR10Plus"));
     VP9Profile3HDR10Plus       = (get_static_field<int>(clazz, "VP9Profile3HDR10Plus"));
+  }
+
+  if(GetSDKVersion() >= 30)
+  {
+    DolbyVisionProfileDvav110  = (get_static_field<int>(clazz, "DolbyVisionProfileDvav110"));
   }
 }
 
@@ -291,6 +321,16 @@ int CJNIMediaCodecInfoCodecCapabilities::COLOR_Format24BitARGB6666(0);
 int CJNIMediaCodecInfoCodecCapabilities::COLOR_Format24BitABGR6666(0);
 int CJNIMediaCodecInfoCodecCapabilities::COLOR_TI_FormatYUV420PackedSemiPlanar(0);
 int CJNIMediaCodecInfoCodecCapabilities::COLOR_QCOM_FormatYUV420SemiPlanar(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_Format32bitABGR2101010(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_Format32bitABGR8888(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_Format64bitABGRFloat(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_FormatRGBAFlexible(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_FormatRGBFlexible(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_FormatSurface(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_FormatYUV420Flexible(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_FormatYUV422Flexible(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_FormatYUV444Flexible(0);
+int CJNIMediaCodecInfoCodecCapabilities::COLOR_FormatYUVP010(0);
 
 std::string CJNIMediaCodecInfoCodecCapabilities::FEATURE_AdaptivePlayback;
 std::string CJNIMediaCodecInfoCodecCapabilities::FEATURE_DynamicTimestamp;
@@ -364,6 +404,11 @@ void CJNIMediaCodecInfoCodecCapabilities::PopulateStaticFields()
     COLOR_QCOM_FormatYUV420SemiPlanar = (get_static_field<int>(clazz, "COLOR_QCOM_FormatYUV420SemiPlanar"));
   }
 
+  if(GetSDKVersion() >= 18)
+  {
+    COLOR_FormatSurface               = (get_static_field<int>(clazz, "COLOR_FormatSurface"));
+  }
+
   if(GetSDKVersion() >= 19)
   {
     FEATURE_AdaptivePlayback = (jcast<std::string>(get_static_field<jhstring>(clazz, "FEATURE_AdaptivePlayback")));
@@ -371,8 +416,18 @@ void CJNIMediaCodecInfoCodecCapabilities::PopulateStaticFields()
 
   if(GetSDKVersion() >= 21)
   {
+    COLOR_FormatYUV420Flexible        = (get_static_field<int>(clazz, "COLOR_FormatYUV420Flexible"));
     FEATURE_SecurePlayback = (jcast<std::string>(get_static_field<jhstring>(clazz, "FEATURE_SecurePlayback")));
     FEATURE_TunneledPlayback = (jcast<std::string>(get_static_field<jhstring>(clazz, "FEATURE_TunneledPlayback")));
+  }
+
+  if(GetSDKVersion() >= 23)
+  {
+    COLOR_Format32bitABGR8888         = (get_static_field<int>(clazz, "COLOR_Format32bitABGR8888"));
+    COLOR_FormatRGBAFlexible          = (get_static_field<int>(clazz, "COLOR_FormatRGBAFlexible"));
+    COLOR_FormatRGBFlexible           = (get_static_field<int>(clazz, "COLOR_FormatRGBFlexible"));
+    COLOR_FormatYUV422Flexible        = (get_static_field<int>(clazz, "COLOR_FormatYUV422Flexible"));
+    COLOR_FormatYUV444Flexible        = (get_static_field<int>(clazz, "COLOR_FormatYUV444Flexible"));
   }
 
   if(GetSDKVersion() >= 24)
@@ -390,6 +445,12 @@ void CJNIMediaCodecInfoCodecCapabilities::PopulateStaticFields()
     FEATURE_DynamicTimestamp = (jcast<std::string>(get_static_field<jhstring>(clazz, "FEATURE_DynamicTimestamp")));
     FEATURE_FrameParsing = (jcast<std::string>(get_static_field<jhstring>(clazz, "FEATURE_FrameParsing")));
     FEATURE_MultipleFrames = (jcast<std::string>(get_static_field<jhstring>(clazz, "FEATURE_MultipleFrames")));
+  }
+  if(GetSDKVersion() >= 33)
+  {
+    COLOR_Format32bitABGR2101010      = (get_static_field<int>(clazz, "COLOR_Format32bitABGR2101010"));
+    COLOR_Format64bitABGRFloat        = (get_static_field<int>(clazz, "COLOR_Format64bitABGRFloat"));
+    COLOR_FormatYUVP010               = (get_static_field<int>(clazz, "COLOR_FormatYUVP010"));
   }
 }
 

--- a/src/MediaCodecInfo.cpp
+++ b/src/MediaCodecInfo.cpp
@@ -64,6 +64,11 @@ int CJNIMediaCodecInfoCodecProfileLevel::H263Level45(0);
 int CJNIMediaCodecInfoCodecProfileLevel::H263Level50(0);
 int CJNIMediaCodecInfoCodecProfileLevel::H263Level60(0);
 int CJNIMediaCodecInfoCodecProfileLevel::H263Level70(0);
+int CJNIMediaCodecInfoCodecProfileLevel::HEVCProfileMain(0);
+int CJNIMediaCodecInfoCodecProfileLevel::HEVCProfileMain10(0);
+int CJNIMediaCodecInfoCodecProfileLevel::HEVCProfileMain10HDR10(0);
+int CJNIMediaCodecInfoCodecProfileLevel::HEVCProfileMain10HDR10Plus(0);
+int CJNIMediaCodecInfoCodecProfileLevel::HEVCProfileMainStill(0);
 int CJNIMediaCodecInfoCodecProfileLevel::MPEG4ProfileSimple(0);
 int CJNIMediaCodecInfoCodecProfileLevel::MPEG4ProfileSimpleScalable(0);
 int CJNIMediaCodecInfoCodecProfileLevel::MPEG4ProfileCore(0);
@@ -102,8 +107,10 @@ int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile0(0);
 int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile1(0);
 int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile2(0);
 int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile2HDR(0);
+int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile2HDR10Plus(0);
 int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile3(0);
 int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile3HDR(0);
+int CJNIMediaCodecInfoCodecProfileLevel::VP9Profile3HDR10Plus(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AV1ProfileMain10(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AV1ProfileMain10HDR10(0);
 int CJNIMediaCodecInfoCodecProfileLevel::AV1ProfileMain10HDR10Plus(0);
@@ -193,8 +200,15 @@ void CJNIMediaCodecInfoCodecProfileLevel::PopulateStaticFields()
     AACObjectELD                = (get_static_field<int>(clazz, "AACObjectELD"));
   }
 
+  if(GetSDKVersion() >= 21)
+  {
+    HEVCProfileMain             = (get_static_field<int>(clazz, "HEVCProfileMain"));
+    HEVCProfileMain10           = (get_static_field<int>(clazz, "HEVCProfileMain10"));
+  }
+
   if(GetSDKVersion() >= 24)
   {
+    HEVCProfileMain10HDR10     = (get_static_field<int>(clazz, "HEVCProfileMain10HDR10"));
     VP9Profile0                = (get_static_field<int>(clazz, "VP9Profile0"));
     VP9Profile1                = (get_static_field<int>(clazz, "VP9Profile1"));
     VP9Profile2                = (get_static_field<int>(clazz, "VP9Profile2"));
@@ -203,12 +217,20 @@ void CJNIMediaCodecInfoCodecProfileLevel::PopulateStaticFields()
     VP9Profile3HDR             = (get_static_field<int>(clazz, "VP9Profile3HDR"));
   }
 
+  if(GetSDKVersion() >= 28)
+  {
+    HEVCProfileMainStill       = (get_static_field<int>(clazz, "HEVCProfileMainStill"));
+  }
+
   if(GetSDKVersion() >= 29)
   {
     AV1ProfileMain10           = (get_static_field<int>(clazz, "AV1ProfileMain10"));
     AV1ProfileMain10HDR10      = (get_static_field<int>(clazz, "AV1ProfileMain10HDR10"));
     AV1ProfileMain10HDR10Plus  = (get_static_field<int>(clazz, "AV1ProfileMain10HDR10Plus"));
     AV1ProfileMain8            = (get_static_field<int>(clazz, "AV1ProfileMain8"));
+    HEVCProfileMain10HDR10Plus = (get_static_field<int>(clazz, "HEVCProfileMain10HDR10Plus"));
+    VP9Profile2HDR10Plus       = (get_static_field<int>(clazz, "VP9Profile2HDR10Plus"));
+    VP9Profile3HDR10Plus       = (get_static_field<int>(clazz, "VP9Profile3HDR10Plus"));
   }
 }
 

--- a/src/MediaCodecInfo.h
+++ b/src/MediaCodecInfo.h
@@ -57,6 +57,17 @@ public:
   static int AVCLevel42;
   static int AVCLevel5;
   static int AVCLevel51;
+  static int DolbyVisionProfileDvav110;
+  static int DolbyVisionProfileDvavPen;
+  static int DolbyVisionProfileDvavPer;
+  static int DolbyVisionProfileDvavSe;
+  static int DolbyVisionProfileDvheDen;
+  static int DolbyVisionProfileDvheDer;
+  static int DolbyVisionProfileDvheDtb;
+  static int DolbyVisionProfileDvheDth;
+  static int DolbyVisionProfileDvheDtr;
+  static int DolbyVisionProfileDvheSt;
+  static int DolbyVisionProfileDvheStn;
   static int H263ProfileBaseline;
   static int H263ProfileH320Coding;
   static int H263ProfileBackwardCompatible;
@@ -203,6 +214,16 @@ public:
   static int COLOR_TI_FormatYUV420PackedSemiPlanar;
   static int COLOR_QCOM_FormatYUV420SemiPlanar;
   static int OMX_QCOM_COLOR_FormatYVU420SemiPlanarInterlace;
+  static int COLOR_Format32bitABGR2101010;
+  static int COLOR_Format32bitABGR8888;
+  static int COLOR_Format64bitABGRFloat;
+  static int COLOR_FormatRGBAFlexible;
+  static int COLOR_FormatRGBFlexible;
+  static int COLOR_FormatSurface;
+  static int COLOR_FormatYUV420Flexible;
+  static int COLOR_FormatYUV422Flexible;
+  static int COLOR_FormatYUV444Flexible;
+  static int COLOR_FormatYUVP010;
 
   static std::string FEATURE_AdaptivePlayback;
   static std::string FEATURE_DynamicTimestamp;

--- a/src/MediaCodecInfo.h
+++ b/src/MediaCodecInfo.h
@@ -74,6 +74,11 @@ public:
   static int H263Level50;
   static int H263Level60;
   static int H263Level70;
+  static int HEVCProfileMain;
+  static int HEVCProfileMain10;
+  static int HEVCProfileMain10HDR10;
+  static int HEVCProfileMain10HDR10Plus;
+  static int HEVCProfileMainStill;
   static int MPEG4ProfileSimple;
   static int MPEG4ProfileSimpleScalable;
   static int MPEG4ProfileCore;
@@ -112,8 +117,10 @@ public:
   static int VP9Profile1;
   static int VP9Profile2;
   static int VP9Profile2HDR;
+  static int VP9Profile2HDR10Plus;
   static int VP9Profile3;
   static int VP9Profile3HDR;
+  static int VP9Profile3HDR10Plus;
   static int AV1ProfileMain10;
   static int AV1ProfileMain10HDR10;
   static int AV1ProfileMain10HDR10Plus;


### PR DESCRIPTION
to be used in Kodi.

Also add two new VP9 profile constants in the class.