### PR TITLE
Listen to network events

### DIFF
--- a/src/ConnectivityManager.cpp
+++ b/src/ConnectivityManager.cpp
@@ -157,4 +157,17 @@ bool CJNIConnectivityManager::getBackgroundDataSetting()
     "getBackgroundDataSetting", "()Z");
 }
 
+void CJNIConnectivityManager::registerDefaultNetworkCallback(const jhobject& networkCallback)
+{
+  call_method<void>(m_object,
+    "registerDefaultNetworkCallback", "(Landroid/net/ConnectivityManager$NetworkCallback;)V",
+    networkCallback);
+}
+
+void CJNIConnectivityManager::unregisterNetworkCallback(const jhobject& networkCallback)
+{
+  call_method<void>(m_object,
+    "unregisterNetworkCallback", "(Landroid/net/ConnectivityManager$NetworkCallback;)V",
+    networkCallback);
+}
 

--- a/src/ConnectivityManager.h
+++ b/src/ConnectivityManager.h
@@ -59,6 +59,8 @@ public:
   bool requestRouteToHost(int, int);
   // Deprecated in API level 15
   bool getBackgroundDataSetting();
+  void registerDefaultNetworkCallback(const jni::jhobject& networkCallback);
+  void unregisterNetworkCallback(const jni::jhobject& networkCallback);
 
   static void PopulateStaticFields();
   // Deprecated in API level 28


### PR DESCRIPTION
To find out about network events, use the [NetworkCallback](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback) class together with [ConnectivityManager.registerDefaultNetworkCallback(NetworkCallback)](https://developer.android.com/reference/android/net/ConnectivityManager#registerDefaultNetworkCallback(android.net.ConnectivityManager.NetworkCallback))