### PR TITLE
HDR type constants

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -63,6 +63,7 @@
 #include "MediaCodecList.h"
 #include "WindowManager.h"
 #include "Resources.h"
+#include "Display.h"
 
 #include <android/native_activity.h>
 
@@ -141,6 +142,7 @@ void CJNIContext::PopulateStaticFields()
   CJNISpeechRecognizer::PopulateStaticFields();
   CJNIMediaCodecList::PopulateStaticFields();
   CJNIWindowManagerLayoutParams::PopulateStaticFields();
+  CJNIDisplayHdrCapabilities::PopulateStaticFields();
 }
 
 CJNIPackageManager CJNIContext::GetPackageManager()

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -50,6 +50,29 @@ float CJNIDisplayMode::getRefreshRate()
 
 /*************/
 
+int CJNIDisplayHdrCapabilities::HDR_TYPE_DOLBY_VISION{0};
+int CJNIDisplayHdrCapabilities::HDR_TYPE_HDR10{0};
+int CJNIDisplayHdrCapabilities::HDR_TYPE_HDR10_PLUS{0};
+int CJNIDisplayHdrCapabilities::HDR_TYPE_HLG{0};
+int CJNIDisplayHdrCapabilities::HDR_TYPE_INVALID{0};
+
+void CJNIDisplayHdrCapabilities::PopulateStaticFields()
+{
+  if (GetSDKVersion() >= 24)
+  {
+    jhclass clazz = find_class("android/view/Display$HdrCapabilities");
+    HDR_TYPE_DOLBY_VISION = (get_static_field<int>(clazz, "HDR_TYPE_DOLBY_VISION"));
+    HDR_TYPE_HDR10 = (get_static_field<int>(clazz, "HDR_TYPE_HDR10"));
+    HDR_TYPE_HLG = (get_static_field<int>(clazz, "HDR_TYPE_HLG"));
+
+    if (GetSDKVersion() >= 29)
+      HDR_TYPE_HDR10_PLUS = (get_static_field<int>(clazz, "HDR_TYPE_HDR10_PLUS"));
+
+    if (GetSDKVersion() >= 34)
+      HDR_TYPE_INVALID = (get_static_field<int>(clazz, "HDR_TYPE_INVALID"));
+  }
+}
+
 std::vector<int> CJNIDisplayHdrCapabilities::getSupportedHdrTypes()
 {
   return jcast<std::vector<int> >(

--- a/src/Display.h
+++ b/src/Display.h
@@ -48,6 +48,14 @@ public:
   // Deprecated in API level 34
   std::vector<int> getSupportedHdrTypes();
 
+  static void PopulateStaticFields();
+
+  static int HDR_TYPE_DOLBY_VISION;
+  static int HDR_TYPE_HDR10;
+  static int HDR_TYPE_HDR10_PLUS;
+  static int HDR_TYPE_HLG;
+  static int HDR_TYPE_INVALID;
+
 protected:
   CJNIDisplayHdrCapabilities();
 };


### PR DESCRIPTION
Add [HDR types](https://developer.android.com/reference/android/view/Display.HdrCapabilities#constants_1) to be used in Kodi.