### PR TITLE
Add StorageManager.getPrimaryStorageVolume method

### DIFF
--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -24,12 +24,26 @@
 
 using namespace jni;
 
-std::string CJNIEnvironment::MEDIA_MOUNTED = "mounted";
+std::string CJNIEnvironment::DIRECTORY_DCIM;
+std::string CJNIEnvironment::DIRECTORY_DOWNLOADS;
+std::string CJNIEnvironment::DIRECTORY_MOVIES;
+std::string CJNIEnvironment::DIRECTORY_MUSIC;
+std::string CJNIEnvironment::DIRECTORY_PICTURES;
+
+std::string CJNIEnvironment::MEDIA_MOUNTED;
+std::string CJNIEnvironment::MEDIA_MOUNTED_READ_ONLY;
 
 void CJNIEnvironment::PopulateStaticFields()
 {
   jhclass c = find_class("android/os/Environment");
-  CJNIEnvironment::MEDIA_MOUNTED          = jcast<std::string>(get_static_field<jhstring>(c,"MEDIA_MOUNTED"));
+  DIRECTORY_DCIM = jcast<std::string>(get_static_field<jhstring>(c, "DIRECTORY_DCIM"));
+  DIRECTORY_DOWNLOADS = jcast<std::string>(get_static_field<jhstring>(c, "DIRECTORY_DOWNLOADS"));
+  DIRECTORY_MOVIES = jcast<std::string>(get_static_field<jhstring>(c, "DIRECTORY_MOVIES"));
+  DIRECTORY_MUSIC = jcast<std::string>(get_static_field<jhstring>(c, "DIRECTORY_MUSIC"));
+  DIRECTORY_PICTURES = jcast<std::string>(get_static_field<jhstring>(c, "DIRECTORY_PICTURES"));
+
+  MEDIA_MOUNTED = jcast<std::string>(get_static_field<jhstring>(c,"MEDIA_MOUNTED"));
+  MEDIA_MOUNTED_READ_ONLY = jcast<std::string>(get_static_field<jhstring>(c,"MEDIA_MOUNTED_READ_ONLY"));
 }
 
 std::string CJNIEnvironment::getExternalStorageState()

--- a/src/Environment.h
+++ b/src/Environment.h
@@ -28,7 +28,14 @@ class CJNIEnvironment : public CJNIBase
 public:
   static void PopulateStaticFields();
 
-  static std::string  MEDIA_MOUNTED;
+  static std::string DIRECTORY_DCIM;
+  static std::string DIRECTORY_DOWNLOADS;
+  static std::string DIRECTORY_MOVIES;
+  static std::string DIRECTORY_MUSIC;
+  static std::string DIRECTORY_PICTURES;
+
+  static std::string MEDIA_MOUNTED;
+  static std::string MEDIA_MOUNTED_READ_ONLY;
 
   static std::string  getExternalStorageState();
   // Deprecated in API level 29

--- a/src/StorageManager.cpp
+++ b/src/StorageManager.cpp
@@ -24,6 +24,12 @@
 
 using namespace jni;
 
+CJNIStorageVolume CJNIStorageManager::getPrimaryStorageVolume()
+{
+  return call_method<jhobject>(m_object, "getPrimaryStorageVolume",
+    "()Landroid/os/storage/StorageVolume;");
+}
+
 CJNIList<CJNIStorageVolume> CJNIStorageManager::getStorageVolumes()
 {
   if (GetSDKVersion() >= 24)

--- a/src/StorageManager.h
+++ b/src/StorageManager.h
@@ -22,8 +22,7 @@
 #include "JNIBase.h"
 
 #include "List.h"
-
-class CJNIStorageVolume;
+#include "StorageVolume.h"
 
 class CJNIStorageManager : public CJNIBase
 {
@@ -31,6 +30,7 @@ public:
   CJNIStorageManager(const jni::jhobject &object) : CJNIBase(object) {};
   ~CJNIStorageManager() {};
 
+  CJNIStorageVolume getPrimaryStorageVolume();
   CJNIList<CJNIStorageVolume> getStorageVolumes();
 
 private:

--- a/src/StorageVolume.cpp
+++ b/src/StorageVolume.cpp
@@ -56,6 +56,11 @@ int CJNIStorageVolume::getDescriptionId()
   }
 }
 
+CJNIFile CJNIStorageVolume::getDirectory()
+{
+  return call_method<jhobject>(m_object, "getDirectory", "()Ljava/io/File;");
+}
+
 bool CJNIStorageVolume::isPrimary()
 {
   jmethodID mid = get_method_id(m_object, "isPrimary", "()Z");

--- a/src/StorageVolume.h
+++ b/src/StorageVolume.h
@@ -22,6 +22,7 @@
 #include "JNIBase.h"
 
 #include "Context.h"
+#include "File.h"
 #include "List.h"
 
 class CJNIStorageVolume : public CJNIBase
@@ -33,6 +34,7 @@ public:
   std::string getPath();
   std::string getDescription(const CJNIContext& context);
   int getDescriptionId();
+  CJNIFile getDirectory();
 
   bool isPrimary();
   bool isRemovable();


### PR DESCRIPTION
Add the `StorageManager.getPrimaryStorageVolume()` method along with the necessary `StorageVolume.getDirectory()` method to replace the deprecated `Environment.getExternalStorageDirectory()` method in API level 29.

Also, add some constants from the `Environment` class.
