### PR TITLE
Share files using FileProvider

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -272,3 +272,10 @@ CJNIResources CJNIContext::getResources()
   return call_method<jhobject>(m_context,
     "getResources", "()Landroid/content/res/Resources;");
 }
+
+void CJNIContext::grantUriPermission(const std::string& package, const CJNIURI& uri, int flags)
+{
+  call_method<void>(m_context,
+    "grantUriPermission", "(Ljava/lang/String;Landroid/net/Uri;I)V",
+    jcast<jhstring>(package), uri.get_raw(), flags);
+}

--- a/src/Context.h
+++ b/src/Context.h
@@ -34,6 +34,7 @@ class CJNIContentResolver;
 class CJNIWindow;
 class CJNIResourcesTheme;
 class CJNIResources;
+class CJNIURI;
 
 class CJNIContext
 {
@@ -70,6 +71,7 @@ public:
   static CJNIWindow getWindow();
   static CJNIResourcesTheme getTheme();
   static CJNIResources getResources();
+  static void grantUriPermission(const std::string& package, const CJNIURI& uri, int flags);
 
 protected:
   CJNIContext(const ANativeActivity *nativeActivity);

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -23,6 +23,17 @@
 
 using namespace jni;
 
+CJNIFile::CJNIFile(const std::string& pathname) : CJNIBase("java/io/File")
+{
+  m_object = new_object(GetClassName(), "<init>", "(Ljava/lang/String;)V", jcast<jhstring>(pathname));
+  m_object.setGlobal();
+}
+
+bool CJNIFile::exists()
+{
+  return call_method<jboolean>(m_object, "exists", "()Z");
+}
+
 std::string CJNIFile::getAbsolutePath()
 {
   return jcast<std::string>(call_method<jhstring>(m_object,

--- a/src/File.h
+++ b/src/File.h
@@ -26,8 +26,10 @@ class CJNIFile : public CJNIBase
 public:
   CJNIFile();
   CJNIFile(const jni::jhobject &file) : CJNIBase(file){};
+  CJNIFile(const std::string& pathname);
   ~CJNIFile(){};
 
+  bool exists();
   std::string getAbsolutePath();
   int64_t getUsableSpace();
 };

--- a/src/FileProvider.cpp
+++ b/src/FileProvider.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileProvider.h"
+
+#include "jutils-details.hpp"
+
+using namespace jni;
+
+const std::string CJNIFileProvider::m_classname = "androidx/core/content/FileProvider";
+
+const CJNIURI CJNIFileProvider::getUriForFile(const CJNIContext& context, const std::string& authority, const CJNIFile& file)
+{
+  const jhclass clazz = CJNIContext::getClassLoader().loadClass(m_classname);
+
+  return call_static_method<jhobject>(clazz,
+    "getUriForFile", "(Landroid/content/Context;Ljava/lang/String;Ljava/io/File;)Landroid/net/Uri;",
+     context.get_raw(), jcast<jhstring>(authority), file.get_raw());
+};

--- a/src/FileProvider.h
+++ b/src/FileProvider.h
@@ -1,0 +1,22 @@
+#pragma once
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "JNIBase.h"
+#include "Context.h"
+#include "File.h"
+#include "URI.h"
+
+class CJNIFileProvider : public CJNIBase
+{
+public:
+  static const CJNIURI getUriForFile(const CJNIContext& context, const std::string& authority, const CJNIFile& file);
+
+private:
+  static const std::string m_classname;
+};

--- a/src/Intent.cpp
+++ b/src/Intent.cpp
@@ -43,6 +43,8 @@ std::string CJNIIntent::ACTION_SCREEN_OFF;
 std::string CJNIIntent::ACTION_SEARCH;
 std::string CJNIIntent::ACTION_VIEW;
 std::string CJNIIntent::EXTRA_KEY_EVENT;
+int CJNIIntent::FLAG_GRANT_READ_URI_PERMISSION;
+int CJNIIntent::FLAG_GRANT_WRITE_URI_PERMISSION;
 
 static std::string s_className = "android/content/Intent";
 
@@ -67,6 +69,8 @@ void CJNIIntent::PopulateStaticFields()
   ACTION_SEARCH = jcast<std::string>(get_static_field<jhstring>(clazz,"ACTION_SEARCH"));
   ACTION_VIEW = jcast<std::string>(get_static_field<jhstring>(clazz,"ACTION_VIEW"));
   EXTRA_KEY_EVENT  = jcast<std::string>(get_static_field<jhstring>(clazz,"EXTRA_KEY_EVENT"));
+  FLAG_GRANT_READ_URI_PERMISSION = (get_static_field<int>(clazz, "FLAG_GRANT_READ_URI_PERMISSION"));
+  FLAG_GRANT_WRITE_URI_PERMISSION = (get_static_field<int>(clazz, "FLAG_GRANT_WRITE_URI_PERMISSION"));
 }
 
 CJNIIntent::CJNIIntent(const std::string &action)

--- a/src/Intent.h
+++ b/src/Intent.h
@@ -83,4 +83,6 @@ public:
   static std::string ACTION_SEARCH;
   static std::string ACTION_VIEW;
   static std::string EXTRA_KEY_EVENT;
+  static int FLAG_GRANT_READ_URI_PERMISSION;
+  static int FLAG_GRANT_WRITE_URI_PERMISSION;
 };


### PR DESCRIPTION
Add `FileProvider` class and `getUriForFile()` method and other related changes needed to work:

- Add `Context.grantUriPermission()` method
- A `File` constructor
- Two `Intent` constants: `FLAG_GRANT_READ_URI_PERMISSION` and `FLAG_GRANT_WRITE_URI_PERMISSION`