### PR TITLE
Fix and cleanup class name / path

### DIFF
--- a/jutils/jlog.hpp
+++ b/jutils/jlog.hpp
@@ -22,7 +22,7 @@
 
 #include <android/log.h>
 
-#define LOG_TAG "org.xbmc.kodi [libandroidjni]"
+#define LOG_TAG "Kodi [libandroidjni]"
 #define LOGVERB(...) __android_log_print(ANDROID_LOG_VERBOSE, LOG_TAG, __VA_ARGS__)
 #define LOGDEBUG(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 #define LOGINFO(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)

--- a/src/AudioTimestamp.cpp
+++ b/src/AudioTimestamp.cpp
@@ -22,7 +22,7 @@
 
 using namespace jni;
 
-CJNIAudioTimestamp::CJNIAudioTimestamp() : CJNIBase("android.media.AudioTimestamp")
+CJNIAudioTimestamp::CJNIAudioTimestamp() : CJNIBase("android/media/AudioTimestamp")
 {
   m_object = new_object(GetClassName());
   m_object.setGlobal();

--- a/src/BroadcastReceiver.cpp
+++ b/src/BroadcastReceiver.cpp
@@ -30,7 +30,7 @@ using namespace jni;
 CJNIBroadcastReceiver *CJNIBroadcastReceiver::m_receiverInstance(NULL);
 CJNIBroadcastReceiver::CJNIBroadcastReceiver(const std::string &className) : CJNIBase(className)
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetDotClassName(className)));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetClassNameAsPath()));
   m_receiverInstance = this;
   m_object.setGlobal();
 }

--- a/src/ClassLoader.cpp
+++ b/src/ClassLoader.cpp
@@ -32,9 +32,8 @@ CJNIClassLoader::CJNIClassLoader(const std::string& dexPath) : CJNIBase("dalvik/
 	m_object.setGlobal();
 }
 
-jhclass CJNIClassLoader::loadClass(std::string className)
+jhclass CJNIClassLoader::loadClass(std::string classPath)
 {
-  return call_method<jhclass>(m_object,
-    "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;",
-    jcast<jhstring>(className)); 
+  return call_method<jhclass>(m_object, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;",
+                              jcast<jhstring>(classPath));
 }

--- a/src/ClassLoader.h
+++ b/src/ClassLoader.h
@@ -28,7 +28,12 @@ public:
   CJNIClassLoader(const std::string& dexPath);
   ~CJNIClassLoader() {};
 
-  jni::jhclass loadClass(std::string className);
+  /*!
+   * \brief Load the class at specified fully qualified class name path.
+   * \param classPath The fully qualified class name path (this.is.an.example).
+   * \return The class, otherwise throws an exception for class not found.
+   */
+  jni::jhclass loadClass(std::string classPath);
 
 private:
   CJNIClassLoader();

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -95,6 +95,8 @@ CJNIContext::~CJNIContext()
 
 void CJNIContext::PopulateStaticFields()
 {
+  CJNIBase::SetBaseClassName(CJNIBase::ClassPathToName(CJNIContext::getPackageName()));
+
   jhclass clazz = find_class("android/content/Context");
   ACTIVITY_SERVICE = jcast<std::string>(get_static_field<jhstring>(clazz,"ACTIVITY_SERVICE"));
   AUDIO_SERVICE = jcast<std::string>(get_static_field<jhstring>(clazz,"AUDIO_SERVICE"));

--- a/src/FileProvider.cpp
+++ b/src/FileProvider.cpp
@@ -16,7 +16,7 @@ const std::string CJNIFileProvider::m_classname = "androidx/core/content/FilePro
 
 const CJNIURI CJNIFileProvider::getUriForFile(const CJNIContext& context, const std::string& authority, const CJNIFile& file)
 {
-  const jhclass clazz = CJNIContext::getClassLoader().loadClass(m_classname);
+  const jhclass clazz = CJNIContext::getClassLoader().loadClass(ClassNameToPath(m_classname));
 
   return call_static_method<jhobject>(clazz,
     "getUriForFile", "(Landroid/content/Context;Ljava/lang/String;Ljava/io/File;)Landroid/net/Uri;",

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -33,12 +33,9 @@ using namespace jni;
 CJNIInputManagerInputDeviceListener* CJNIInputManagerInputDeviceListener::m_listenerInstance = nullptr;
 
 CJNIInputManagerInputDeviceListener::CJNIInputManagerInputDeviceListener()
-  : CJNIBase(CJNIContext::getPackageName() + ".XBMCInputDeviceListener")
+  : CJNIBase("/XBMCInputDeviceListener")
 {
-  // Convert "the/class/name" to "the.class.name" as loadClass() expects it.
-  std::string dotClassName = GetClassName();
-  std::replace(dotClassName.begin(), dotClassName.end(), '/', '.');
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(dotClassName));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetClassNameAsPath()));
   m_object.setGlobal();
 
   m_listenerInstance = this;

--- a/src/JNIBase.cpp
+++ b/src/JNIBase.cpp
@@ -22,17 +22,26 @@
 #include "jutils-details.hpp"
 
 #include <algorithm>
+#include <cassert>
 
 using namespace jni;
 int CJNIBase::m_sdk_version = -1;
 int CJNIBase::RESULT_OK = -1;
 int CJNIBase::RESULT_CANCELED = 0;
 
-CJNIBase::CJNIBase(std::string classname)
+CJNIBase::CJNIBase(std::string className)
 {
-  // Convert "the.class.name" to "the/class/name"
-  m_className = classname;
-  std::replace(m_className.begin(), m_className.end(), '.', '/');
+  // If starts with "/" add the base class name prefix (e.g. org/xbmc/kodi)
+  if (!className.empty() && className.front() == '/')
+  {
+    assert(
+        !m_baseClassName.empty() &&
+        "SetBaseClassName() must be called before instantiating classes with a relative '/' path. "
+        "The SetBaseClassName() should be set from CJNIContext or independently from CJNIBase.");
+    className = GetBaseClassName() + className;
+  }
+
+  m_className = className;
 }
 
 CJNIBase::CJNIBase(const jhobject &object):
@@ -47,6 +56,13 @@ CJNIBase::~CJNIBase()
     return;
 }
 
+std::string CJNIBase::GetClassNameAsPath() const
+{
+  std::string classPath = m_className;
+  std::replace(classPath.begin(), classPath.end(), '.', '/');
+  return classPath;
+}
+
 void CJNIBase::SetSDKVersion(int version)
 {
   m_sdk_version = version;
@@ -57,11 +73,28 @@ int CJNIBase::GetSDKVersion()
   return m_sdk_version;
 }
 
-const std::string CJNIBase::GetDotClassName(const std::string & classname)
+const std::string CJNIBase::GetBaseClassName()
 {
-  std::string dotClassName = classname;
-  std::replace(dotClassName.begin(), dotClassName.end(), '/', '.');
-  return dotClassName;
+  return m_baseClassName;
+}
+
+void CJNIBase::SetBaseClassName(const std::string& baseClassName)
+{
+  m_baseClassName = baseClassName;
+  if (!m_baseClassName.empty() && m_baseClassName.back() == '/')
+    m_baseClassName.pop_back();
+}
+
+std::string CJNIBase::ClassNameToPath(std::string className)
+{
+  std::replace(className.begin(), className.end(), '/', '.');
+  return className;
+}
+
+std::string CJNIBase::ClassPathToName(std::string classPath)
+{
+  std::replace(classPath.begin(), classPath.end(), '.', '/');
+  return classPath;
 }
 
 const std::string CJNIBase::ExceptionToString()

--- a/src/JNIBase.h
+++ b/src/JNIBase.h
@@ -35,6 +35,19 @@ public:
   const jni::jhobject& get_raw() const { return m_object; }
   static int GetSDKVersion();
   static void SetSDKVersion(int);
+
+  /*!
+   * \brief Get fully qualified "base" class name path.
+   * \return The fully qualified base class name path (this/is/an/example)
+   */
+  static const std::string GetBaseClassName();
+
+  /*!
+   * \brief Set the fully qualified "base" class name path (e.g. Kodi package name).
+   * \param baseClassName The base class name (this/is/an/example)
+   */
+  static void SetBaseClassName(const std::string& baseClassName);
+
   const static std::string ExceptionToString();
 
   static int RESULT_OK;
@@ -43,16 +56,42 @@ public:
 protected:
   CJNIBase() {}
   CJNIBase(jni::jhobject const& object);
-  CJNIBase(std::string classname);
+
+  /*!
+   * \brief Construct CJNIBase by class name.
+   * \param className Can be a class name, or relative class name,
+   *                  so when begin with "/" will be automatically added the "base" class name prefix e.g. org/xbmc/kodi
+   */
+  CJNIBase(std::string className);
   virtual ~CJNIBase();
 
   const std::string& GetClassName() const {return m_className;}
-  static const std::string GetDotClassName(const std::string & classname);
+
+  /*!
+   * \brief Get class name as fully qualified class name path.
+   * \return The fully qualified class name path (this.is.an.example)
+   */
+  std::string GetClassNameAsPath() const;
+
+  /*!
+   * \brief Convert a class name to a fully qualified class name path.
+   * \param className The class name (this/is/an/example)
+   * \return The fully qualified class name path (this.is.an.example)
+   */
+  static std::string ClassNameToPath(std::string className);
+
+  /*!
+   * \brief Convert a fully qualified class name path to class name.
+   * \param classPath The fully qualified class name path (this.is.an.example)
+   * \return The class name (this/is/an/example)
+   */
+  static std::string ClassPathToName(std::string classPath);
 
   jni::jhobject m_object;
 
 private:
   std::string m_className;
+  static inline std::string m_baseClassName{};
   static int m_sdk_version;
 };
 

--- a/src/MediaDrmOnEventListener.cpp
+++ b/src/MediaDrmOnEventListener.cpp
@@ -26,12 +26,12 @@
 
 using namespace jni;
 
-static std::string s_className =  "org/xbmc/kodi/interfaces/XBMCMediaDrmOnEventListener";
+static std::string s_className =  "/interfaces/XBMCMediaDrmOnEventListener";
 
 CJNIMediaDrmOnEventListener::CJNIMediaDrmOnEventListener(CJNIClassLoader &loader)
   : CJNIBase(s_className)
 {
-  jhclass clazz = loader.loadClass(GetDotClassName(s_className));
+  jhclass clazz = loader.loadClass(GetClassNameAsPath());
 
   JNINativeMethod methods[] =
   {

--- a/src/MediaDrmOnKeyStatusChangeListener.cpp
+++ b/src/MediaDrmOnKeyStatusChangeListener.cpp
@@ -27,12 +27,12 @@
 
 using namespace jni;
 
-static std::string s_className =  "org/xbmc/kodi/interfaces/XBMCMediaDrmOnKeyStatusChangeListener";
+static std::string s_className =  "/interfaces/XBMCMediaDrmOnKeyStatusChangeListener";
 
 CJNIMediaDrmOnKeyStatusChangeListener::CJNIMediaDrmOnKeyStatusChangeListener(CJNIClassLoader &loader)
   : CJNIBase(s_className)
 {
-  jhclass clazz = loader.loadClass(GetDotClassName(s_className));
+  jhclass clazz = loader.loadClass(GetClassNameAsPath());
 
   JNINativeMethod methods[] = 
   {

--- a/src/Notification.cpp
+++ b/src/Notification.cpp
@@ -154,6 +154,6 @@ void CJNINotification::PopulateStaticFields()
 CJNINotification::CJNINotification()
 : CJNIBase(CJNINotification::m_classname)
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetDotClassName(CJNINotification::m_classname)));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(ClassNameToPath(CJNINotification::m_classname)));
   m_object.setGlobal();
 }

--- a/src/RecognizerIntent.cpp
+++ b/src/RecognizerIntent.cpp
@@ -28,6 +28,6 @@ void CJNIRecognizerIntent::PopulateStaticFields()
 CJNIRecognizerIntent::CJNIRecognizerIntent()
 : CJNIBase(CJNIRecognizerIntent::m_classname)
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetDotClassName(m_classname)));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(ClassNameToPath(m_classname)));
   m_object.setGlobal();
 }


### PR DESCRIPTION
An issue has been raised when libandroidjni was used as a dependency of InputStream Adaptive
https://github.com/xbmc/inputstream.adaptive/issues/1997

where the `CJNIMediaDrmOnEventListener` has the class name hardcoded with the "base" class name
or in other hand the kodi package name

https://github.com/xbmc/libandroidjni/blob/59b68509c1d175db2610afeb2daedcdb5e1a77a4/src/MediaDrmOnEventListener.cpp#L28

while investigating for a fix i noticed also some confusion between class names / paths uses i mean "the/class/name" vs "the.class.name", where in some cases both are mixed

"the/class/name" --> can be defined as "class name"
"the.class.name" --> can be defined as "fully qualified class name" aka path

Based on these definitions i cleaned up the code by adding more clear methods descriptions to avoid future mixed usages

the `CJNIBase` has the new `SetBaseClassName` that can be used by add-ons to set the "base" class name provided by InputStream android interface (example on https://github.com/xbmc/inputstream.adaptive/pull/2007)

