### PR TITLE
Update JNI version from 1.4 to 1.6

### DIFF
--- a/src/JNIThreading.cpp
+++ b/src/JNIThreading.cpp
@@ -111,7 +111,7 @@ void xbmc_save_jnienv(JNIEnv *env)
 
 jint xbmc_jni_on_load(JavaVM *vm, JNIEnv *env)
 {
-    jint jversion = JNI_VERSION_1_4;
+    jint jversion = JNI_VERSION_1_6;
 
     if (!env)
         return -1;


### PR DESCRIPTION
This PR updates the JNI version returned from `JNI_VERSION_1_4` to `JNI_VERSION_1_6`.

Version 1.6 is the baseline for Android while maintaining broad compatibility.