### PR TITLE
[JNIBase] Fix inverted class path replace and cleanups

### DIFF
--- a/src/BroadcastReceiver.cpp
+++ b/src/BroadcastReceiver.cpp
@@ -30,7 +30,7 @@ using namespace jni;
 CJNIBroadcastReceiver *CJNIBroadcastReceiver::m_receiverInstance(NULL);
 CJNIBroadcastReceiver::CJNIBroadcastReceiver(const std::string &className) : CJNIBase(className)
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetDotClassName()));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(ToDotClassName(className)));
   m_receiverInstance = this;
   m_object.setGlobal();
 }

--- a/src/BroadcastReceiver.cpp
+++ b/src/BroadcastReceiver.cpp
@@ -30,7 +30,7 @@ using namespace jni;
 CJNIBroadcastReceiver *CJNIBroadcastReceiver::m_receiverInstance(NULL);
 CJNIBroadcastReceiver::CJNIBroadcastReceiver(const std::string &className) : CJNIBase(className)
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetClassNameAsPath()));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetDotClassName()));
   m_receiverInstance = this;
   m_object.setGlobal();
 }

--- a/src/ClassLoader.cpp
+++ b/src/ClassLoader.cpp
@@ -32,8 +32,8 @@ CJNIClassLoader::CJNIClassLoader(const std::string& dexPath) : CJNIBase("dalvik/
 	m_object.setGlobal();
 }
 
-jhclass CJNIClassLoader::loadClass(std::string classPath)
+jhclass CJNIClassLoader::loadClass(std::string className)
 {
   return call_method<jhclass>(m_object, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;",
-                              jcast<jhstring>(classPath));
+                              jcast<jhstring>(className));
 }

--- a/src/ClassLoader.h
+++ b/src/ClassLoader.h
@@ -30,10 +30,10 @@ public:
 
   /*!
    * \brief Load the class at specified fully qualified class name path.
-   * \param classPath The fully qualified class name path (this.is.an.example).
+   * \param className The fully qualified class name (this.is.an.example).
    * \return The class, otherwise throws an exception for class not found.
    */
-  jni::jhclass loadClass(std::string classPath);
+  jni::jhclass loadClass(std::string className);
 
 private:
   CJNIClassLoader();

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -95,7 +95,7 @@ CJNIContext::~CJNIContext()
 
 void CJNIContext::PopulateStaticFields()
 {
-  CJNIBase::SetBaseClassName(CJNIBase::ClassPathToName(CJNIContext::getPackageName()));
+  CJNIBase::SetBaseClassName(CJNIBase::ToClassName(CJNIContext::getPackageName()));
 
   jhclass clazz = find_class("android/content/Context");
   ACTIVITY_SERVICE = jcast<std::string>(get_static_field<jhstring>(clazz,"ACTIVITY_SERVICE"));

--- a/src/FileProvider.cpp
+++ b/src/FileProvider.cpp
@@ -16,7 +16,7 @@ const std::string CJNIFileProvider::m_classname = "androidx/core/content/FilePro
 
 const CJNIURI CJNIFileProvider::getUriForFile(const CJNIContext& context, const std::string& authority, const CJNIFile& file)
 {
-  const jhclass clazz = CJNIContext::getClassLoader().loadClass(ClassNameToPath(m_classname));
+  const jhclass clazz = CJNIContext::getClassLoader().loadClass(ToDotClassName(m_classname));
 
   return call_static_method<jhobject>(clazz,
     "getUriForFile", "(Landroid/content/Context;Ljava/lang/String;Ljava/io/File;)Landroid/net/Uri;",

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -35,7 +35,7 @@ CJNIInputManagerInputDeviceListener* CJNIInputManagerInputDeviceListener::m_list
 CJNIInputManagerInputDeviceListener::CJNIInputManagerInputDeviceListener()
   : CJNIBase("/XBMCInputDeviceListener")
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetClassNameAsPath()));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetDotClassName()));
   m_object.setGlobal();
 
   m_listenerInstance = this;

--- a/src/JNIBase.cpp
+++ b/src/JNIBase.cpp
@@ -56,11 +56,11 @@ CJNIBase::~CJNIBase()
     return;
 }
 
-std::string CJNIBase::GetClassNameAsPath() const
+std::string CJNIBase::GetDotClassName() const
 {
-  std::string classPath = m_className;
-  std::replace(classPath.begin(), classPath.end(), '/', '.');
-  return classPath;
+  std::string className = m_className;
+  std::replace(className.begin(), className.end(), '/', '.');
+  return className;
 }
 
 void CJNIBase::SetSDKVersion(int version)
@@ -85,16 +85,16 @@ void CJNIBase::SetBaseClassName(const std::string& baseClassName)
     m_baseClassName.pop_back();
 }
 
-std::string CJNIBase::ClassNameToPath(std::string className)
+std::string CJNIBase::ToDotClassName(std::string className)
 {
   std::replace(className.begin(), className.end(), '/', '.');
   return className;
 }
 
-std::string CJNIBase::ClassPathToName(std::string classPath)
+std::string CJNIBase::ToClassName(std::string className)
 {
-  std::replace(classPath.begin(), classPath.end(), '.', '/');
-  return classPath;
+  std::replace(className.begin(), className.end(), '.', '/');
+  return className;
 }
 
 const std::string CJNIBase::ExceptionToString()

--- a/src/JNIBase.cpp
+++ b/src/JNIBase.cpp
@@ -59,7 +59,7 @@ CJNIBase::~CJNIBase()
 std::string CJNIBase::GetClassNameAsPath() const
 {
   std::string classPath = m_className;
-  std::replace(classPath.begin(), classPath.end(), '.', '/');
+  std::replace(classPath.begin(), classPath.end(), '/', '.');
   return classPath;
 }
 

--- a/src/JNIBase.h
+++ b/src/JNIBase.h
@@ -37,14 +37,14 @@ public:
   static void SetSDKVersion(int);
 
   /*!
-   * \brief Get fully qualified "base" class name path.
-   * \return The fully qualified base class name path (this/is/an/example)
+   * \brief Get the "base" class name with slash notation.
+   * \return The "base" class name with slash notation (this/is/an/example)
    */
   static const std::string GetBaseClassName();
 
   /*!
-   * \brief Set the fully qualified "base" class name path (e.g. Kodi package name).
-   * \param baseClassName The base class name (this/is/an/example)
+   * \brief Set the "base" class name with slash notation (e.g. Kodi package name).
+   * \param baseClassName The base class name with slash notation (this/is/an/example)
    */
   static void SetBaseClassName(const std::string& baseClassName);
 
@@ -65,27 +65,31 @@ protected:
   CJNIBase(std::string className);
   virtual ~CJNIBase();
 
+  /*!
+   * \brief Get the class name with slash notation.
+   * \return The class name (this/is/an/example)
+   */
   const std::string& GetClassName() const {return m_className;}
 
   /*!
-   * \brief Get class name as fully qualified class name path.
-   * \return The fully qualified class name path (this.is.an.example)
+   * \brief Get the class name with dot notation, as fully qualified class name.
+   * \return The fully qualified class name (this.is.an.example)
    */
-  std::string GetClassNameAsPath() const;
+  std::string GetDotClassName() const;
 
   /*!
-   * \brief Convert a class name to a fully qualified class name path.
+   * \brief Convert a class name to a class name with dot notation, as fully qualified class name.
    * \param className The class name (this/is/an/example)
-   * \return The fully qualified class name path (this.is.an.example)
+   * \return The fully qualified class name (this.is.an.example)
    */
-  static std::string ClassNameToPath(std::string className);
+  static std::string ToDotClassName(std::string className);
 
   /*!
-   * \brief Convert a fully qualified class name path to class name.
-   * \param classPath The fully qualified class name path (this.is.an.example)
-   * \return The class name (this/is/an/example)
+   * \brief Convert a fully qualified class name to class name with slash notation.
+   * \param className The fully qualified class name (this.is.an.example)
+   * \return The class name with slash notation (this/is/an/example)
    */
-  static std::string ClassPathToName(std::string classPath);
+  static std::string ToClassName(std::string className);
 
   jni::jhobject m_object;
 

--- a/src/MediaDrmOnEventListener.cpp
+++ b/src/MediaDrmOnEventListener.cpp
@@ -31,7 +31,7 @@ static std::string s_className =  "/interfaces/XBMCMediaDrmOnEventListener";
 CJNIMediaDrmOnEventListener::CJNIMediaDrmOnEventListener(CJNIClassLoader &loader)
   : CJNIBase(s_className)
 {
-  jhclass clazz = loader.loadClass(GetClassNameAsPath());
+  jhclass clazz = loader.loadClass(GetDotClassName());
 
   JNINativeMethod methods[] =
   {

--- a/src/MediaDrmOnKeyStatusChangeListener.cpp
+++ b/src/MediaDrmOnKeyStatusChangeListener.cpp
@@ -32,7 +32,7 @@ static std::string s_className =  "/interfaces/XBMCMediaDrmOnKeyStatusChangeList
 CJNIMediaDrmOnKeyStatusChangeListener::CJNIMediaDrmOnKeyStatusChangeListener(CJNIClassLoader &loader)
   : CJNIBase(s_className)
 {
-  jhclass clazz = loader.loadClass(GetClassNameAsPath());
+  jhclass clazz = loader.loadClass(GetDotClassName());
 
   JNINativeMethod methods[] = 
   {

--- a/src/Notification.cpp
+++ b/src/Notification.cpp
@@ -154,6 +154,6 @@ void CJNINotification::PopulateStaticFields()
 CJNINotification::CJNINotification()
 : CJNIBase(CJNINotification::m_classname)
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(ClassNameToPath(CJNINotification::m_classname)));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(ToDotClassName(CJNINotification::m_classname)));
   m_object.setGlobal();
 }

--- a/src/RecognizerIntent.cpp
+++ b/src/RecognizerIntent.cpp
@@ -28,6 +28,6 @@ void CJNIRecognizerIntent::PopulateStaticFields()
 CJNIRecognizerIntent::CJNIRecognizerIntent()
 : CJNIBase(CJNIRecognizerIntent::m_classname)
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(ClassNameToPath(m_classname)));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(ToDotClassName(m_classname)));
   m_object.setGlobal();
 }


### PR DESCRIPTION
- Reverted some of get "path" method (GetClassNameAsPath) introduced from https://github.com/xbmc/libandroidjni/pull/56 that for unknown reason the value such as "s_className" is not passed to the JNI Base constructor and can lead to crashes, other reverts on xbmc PR

- Cleanup some JNI methods names to try avoid AI become crazy with false positives so to make more clear class name slash/dot notations

tested DRM playback with ISA on shield