### PR TITLE
update cmake_minimum_required version in range of 3.18 to 4.0 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # cmake -DCMAKE_BUILD_TYPE=Debug ..
 # cmake -DCMAKE_BUILD_TYPE=Release ..
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.18...4.0)
 project(androidjni)
 
 # Compiler warning and optimization flags


### PR DESCRIPTION
This needed as on newer cmake versions it must be minimum 3.5 otherwise it brings the following error message.
```
[ 11%] Performing configure step for 'build-libandroidjni'
CMake Error at CMakeLists.txt:3 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

-- Configuring incomplete, errors occurred!
```

As the CMakeLists.txt here is very small the version increase is enough and nothing else needed.
With version 3.18 is it equal to Kodi's one.